### PR TITLE
Updated link to wiki

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -29,7 +29,7 @@ Alternative backends:
 * ActiveRecord (optionally: ActiveRecord::Missing and ActiveRecord::StoreProcs)
 * KeyValue (uses active_support/json and cannot store procs)
 
-For more information and lots of resources see: "http://rails-i18n.org/wiki":http://rails-i18n.org/wiki
+For more information and lots of resources see: "http://ruby-i18n.org/wiki":http://ruby-i18n.org/wiki
 
 h2. Installation
 


### PR DESCRIPTION
The link http://rails-i18n.org/wiki is out of date.  I believe it should be http://ruby-i18n.org/wiki instead.

Thank you,
Steven
