### PR TITLE
ActiveRecord backend will work in Rails 3

### DIFF
--- a/test/api/active_record_test.rb
+++ b/test/api/active_record_test.rb
@@ -31,5 +31,10 @@ class I18nActiveRecordApiTest < Test::Unit::TestCase
   test "must have reload! method" do
     assert_respond_to I18n.backend.class, :reload!
   end
+
+  test "must have translate method" do
+    assert_respond_to I18n.backend.class, :translate
+  end
+
   
 end if defined?(ActiveRecord)


### PR DESCRIPTION
Backend has no translate method defined =)
Implementation of translate method added, existence of those methods is tested now.
