### PR TITLE
Change in ruby gems version

### DIFF
--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.platform     = Gem::Platform::RUBY
   s.require_path = 'lib'
   s.rubyforge_project = '[none]'
-  s.required_rubygems_version = '>= 1.3.6'
+  s.required_rubygems_version = '>= 1.3.5'
 end


### PR DESCRIPTION
In response to issue svenfuchs/i18n#43

This makes no sense, why have stricter requirements towards installation when the stricter requirements gain you nothing? What about those of us who don't use bundler or rails, but still need i18n? 
