### PR TITLE
Key collisions in Ruby < 1.9.

### DIFF
--- a/lib/i18n/backend/cache.rb
+++ b/lib/i18n/backend/cache.rb
@@ -84,14 +84,13 @@ module I18n
 
         def cache_key(locale, key, options)
           # This assumes that only simple, native Ruby values are passed to I18n.translate.
-          "i18n/#{I18n.cache_namespace}/#{locale}/#{key.hash}/#{HASH_HASH ? options.hash : options.inspect.hash}"
+          "i18n/#{I18n.cache_namespace}/#{locale}/#{key.hash}/#{USE_INSPECT_HASH ? options.inspect.hash : options.hash}"
         end
 
       private
-        # In Ruby < 1.8.7 {}.hash != {}.hash
-        # (see http://paulbarry.com/articles/2009/09/14/why-rails-3-will-require-ruby-1-8-7)
-        # If options.inspect.hash does not work for you for some reason, patches are very welcome :)
-        HASH_HASH = RUBY_VERSION >= "1.8.7"
+        # In Ruby < 1.9 the following is true: { :foo => 1, :bar => 2 }.hash == { :foo => 2, :bar => 1 }.hash
+        # Therefore we must use the hash of the inspect string instead to avoid cache key colisions.
+        USE_INSPECT_HASH = RUBY_VERSION <= "1.9"
 
     end
   end

--- a/test/backend/cache_test.rb
+++ b/test/backend/cache_test.rb
@@ -60,7 +60,19 @@ class I18nBackendCacheTest < Test::Unit::TestCase
   end
 
   test "adds locale and hash of key and hash of options" do
-    assert_equal "i18n//en/#{:foo.hash}/#{{:bar=>1}.hash}", I18n.backend.send(:cache_key, :en, :foo, {:bar=>1})
+    options = { :bar=>1 }
+    options_hash = I18n::Backend::Cache::USE_INSPECT_HASH ? options.inspect.hash : options.hash
+    assert_equal "i18n//en/#{:foo.hash}/#{options_hash}", I18n.backend.send(:cache_key, :en, :foo, options)
+  end
+
+  test "keys should not be equal" do
+    interpolation_values1 = { :foo => 1, :bar => 2 }
+    interpolation_values2 = { :foo => 2, :bar => 1 }
+    
+    key1 = I18n.backend.send(:cache_key, :en, :some_key, interpolation_values1)
+    key2 = I18n.backend.send(:cache_key, :en, :some_key, interpolation_values2)
+    
+    assert key1 != key2
   end
 
   protected


### PR DESCRIPTION
In Ruby < 1.9 the following seem to be true: { :foo => 1, :bar => 2 }.hash == { :foo => 2, :bar => 1 }.hash

Therefore we must use the hash of the inspect string instead of the #hash method to avoid cache key collisions for Ruby versions older than 1.9.

I've added a test that proves the problem.

I'd appreciate if you would look at my commit and let me know what you think.

Thanks.
