### PR TITLE
Rake should set the load path

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require 'rake/testtask'
 task :default => [:test]
 
 Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
   t.pattern = "#{File.dirname(__FILE__)}/test/all.rb"
   t.verbose = true
 end

--- a/test/api/all_features_test.rb
+++ b/test/api/all_features_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 begin
   require 'rubygems'

--- a/test/api/cascade_test.rb
+++ b/test/api/cascade_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nCascadeApiTest < Test::Unit::TestCase
   class Backend < I18n::Backend::Simple

--- a/test/api/chain_test.rb
+++ b/test/api/chain_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nApiChainTest < Test::Unit::TestCase
   def setup

--- a/test/api/fallbacks_test.rb
+++ b/test/api/fallbacks_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nFallbacksApiTest < Test::Unit::TestCase
   class Backend < I18n::Backend::Simple

--- a/test/api/key_value_test.rb
+++ b/test/api/key_value_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 I18n::Tests.setup_rufus_tokyo
 

--- a/test/api/memoize_test.rb
+++ b/test/api/memoize_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nMemoizeBackendWithSimpleApiTest < Test::Unit::TestCase
   include I18n::Tests::Basics

--- a/test/api/pluralization_test.rb
+++ b/test/api/pluralization_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nPluralizationApiTest < Test::Unit::TestCase
   class Backend < I18n::Backend::Simple

--- a/test/api/simple_test.rb
+++ b/test/api/simple_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nSimpleBackendApiTest < Test::Unit::TestCase
   class Backend < I18n::Backend::Simple

--- a/test/backend/cache_test.rb
+++ b/test/backend/cache_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 begin
   require 'active_support'

--- a/test/backend/cascade_test.rb
+++ b/test/backend/cascade_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nBackendCascadeTest < Test::Unit::TestCase
   class Backend < I18n::Backend::Simple

--- a/test/backend/chain_test.rb
+++ b/test/backend/chain_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nBackendChainTest < Test::Unit::TestCase
   def setup

--- a/test/backend/cldr_test.rb
+++ b/test/backend/cldr_test.rb
@@ -1,7 +1,7 @@
-require File.expand_path('../../test_helper', __FILE__)
+# :coding: utf-8
+require 'test_helper'
 
 if defined?(Cldr)
-  $:.unshift(File.expand_path(File.dirname(__FILE__) + '/../')); $:.uniq!
   require 'test_helper'
   require 'i18n/backend/cldr'
   require 'date'

--- a/test/backend/exceptions_test.rb
+++ b/test/backend/exceptions_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nBackendExceptionsTest < Test::Unit::TestCase
   def setup

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nBackendFallbacksTranslateTest < Test::Unit::TestCase
   class Backend < I18n::Backend::Simple

--- a/test/backend/interpolation_compiler_test.rb
+++ b/test/backend/interpolation_compiler_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class InterpolationCompilerTest < Test::Unit::TestCase
   Compiler = I18n::Backend::InterpolationCompiler::Compiler

--- a/test/backend/key_value_test.rb
+++ b/test/backend/key_value_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 I18n::Tests.setup_rufus_tokyo
 

--- a/test/backend/memoize_test.rb
+++ b/test/backend/memoize_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 require 'backend/simple_test'
 

--- a/test/backend/metadata_test.rb
+++ b/test/backend/metadata_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nBackendMetadataTest < Test::Unit::TestCase
   class Backend < I18n::Backend::Simple

--- a/test/backend/pluralization_test.rb
+++ b/test/backend/pluralization_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nBackendPluralizationTest < Test::Unit::TestCase
   class Backend < I18n::Backend::Simple

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nBackendSimpleTest < Test::Unit::TestCase
   def setup

--- a/test/backend/transliterator_test.rb
+++ b/test/backend/transliterator_test.rb
@@ -1,4 +1,5 @@
-require File.expand_path('../../test_helper', __FILE__)
+# :coding: utf-8
+require 'test_helper'
 
 class I18nBackendTransliterator < Test::Unit::TestCase
   def setup

--- a/test/core_ext/hash_test.rb
+++ b/test/core_ext/hash_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 require 'i18n/core_ext/hash'
 
 class I18nCoreExtHashInterpolationTest < Test::Unit::TestCase

--- a/test/core_ext/string/interpolate_test.rb
+++ b/test/core_ext/string/interpolate_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../test_helper', __FILE__)
+require 'test_helper'
 
 # thanks to Masao's String extensions these should work the same in
 # Ruby 1.8 (patched) and Ruby 1.9 (native)

--- a/test/gettext/api_test.rb
+++ b/test/gettext/api_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 require 'i18n/gettext/helpers'
 
 include I18n::Gettext::Helpers

--- a/test/gettext/backend_test.rb
+++ b/test/gettext/backend_test.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 
+require 'test_helper'
+
 # apparently Ruby 1.9.1p129 has encoding problems with the gettext po parser
 unless RUBY_VERSION == '1.9.1' && RUBY_PATCHLEVEL <= 129
-
-  require File.expand_path('../../test_helper', __FILE__)
 
   class I18nGettextBackendTest < Test::Unit::TestCase
     include I18n::Gettext::Helpers

--- a/test/i18n_exceptions_test.rb
+++ b/test/i18n_exceptions_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nExceptionsTest < Test::Unit::TestCase
   def test_invalid_locale_stores_locale

--- a/test/i18n_load_path_test.rb
+++ b/test/i18n_load_path_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nLoadPathTest < Test::Unit::TestCase
   def setup

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../test_helper', __FILE__)
+require 'test_helper'
 
 class I18nTest < Test::Unit::TestCase
   def setup

--- a/test/locale/fallbacks_test.rb
+++ b/test/locale/fallbacks_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require 'test_helper'
 
 include I18n::Locale
 

--- a/test/locale/tag/rfc4646_test.rb
+++ b/test/locale/tag/rfc4646_test.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-$:.unshift(File.expand_path(File.dirname(__FILE__) + '/../../')); $:.uniq!
 require 'test_helper'
 
 class I18nLocaleTagRfc4646ParserTest < Test::Unit::TestCase

--- a/test/locale/tag/simple_test.rb
+++ b/test/locale/tag/simple_test.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-$:.unshift(File.expand_path(File.dirname(__FILE__) + '/../../')); $:.uniq!
 require 'test_helper'
 
 class I18nLocaleTagSimpleTest < Test::Unit::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../test_setup', __FILE__)
+require 'test_setup'
 
 I18n::Tests.parse_options!
 

--- a/test/test_setup.rb
+++ b/test/test_setup.rb
@@ -15,7 +15,6 @@ def gem(gem_name, *version_requirements)
 end
 
 require 'bundler/setup'
-$:.unshift File.expand_path("../lib", File.dirname(__FILE__))
 require 'i18n'
 require 'mocha'
 require 'test_declarative'


### PR DESCRIPTION
Let Rake set the load path when we run the tests, then we don't have to do File.expand_path everywhere.
