### PR TITLE
Clear cache when new translations are added

### DIFF
--- a/test/backend/cache_test.rb
+++ b/test/backend/cache_test.rb
@@ -19,6 +19,7 @@ class I18nBackendCacheTest < Test::Unit::TestCase
 
   def teardown
     I18n.cache_store = nil
+    I18n.backend.send(:clear_cached_keys)
   end
 
   test "it uses the cache" do
@@ -69,6 +70,58 @@ class I18nBackendCacheTest < Test::Unit::TestCase
     key2 = I18n.backend.send(:cache_key, :en, :some_key, interpolation_values2)
 
     assert key1 != key2
+  end
+
+  test "adds cached key to list of cached keys" do
+    I18n.backend.expects(:lookup).returns('Foo')
+    I18n.t(:foo)
+    assert I18n.backend.send(:cached_keys).include?(I18n.backend.send(:cache_key, :en, :foo, {}))
+  end
+
+  test "adds cached key only once" do
+    I18n.backend.expects(:lookup).returns('Foo')
+    I18n.t(:foo)
+    I18n.t(:foo)
+
+    assert_equal 1, I18n.backend.send(:cached_keys).length
+  end
+
+  test "adds cached key to list of cached keys with options" do
+    I18n.backend.expects(:lookup).returns('Foo')
+    I18n.t(:foo, :default => "bar")
+    assert I18n.backend.send(:cached_keys).include?(I18n.backend.send(:cache_key, :en, :foo, {:default => "bar"}))
+  end
+
+  test "adds cached key to list of cached keys even if exception" do
+    I18n.backend.expects(:lookup).returns(nil)
+    begin
+      I18n.t(:foo)
+    rescue
+    end
+    assert I18n.backend.send(:cached_keys).include?(I18n.backend.send(:cache_key, :en, :foo, {}))
+  end
+
+  test "does not return cached value after cache is cleared" do
+    I18n.backend.expects(:lookup).returns('Foo')
+    I18n.t(:foo)
+    I18n.backend.clear_cache
+
+    assert_equal 0, I18n.backend.send(:cached_keys).length
+    I18n.backend.expects(:lookup).returns('Bar')
+    assert_equal 'Bar', I18n.t(:foo)
+  end
+
+  test "store_translations clears cache" do
+    I18n.backend.expects(:lookup).returns('Foo')
+    I18n.t(:foo)
+    begin
+      I18n.backend.store_translations(:en, nil)
+    rescue
+    end
+
+    assert_equal 0, I18n.backend.send(:cached_keys).length
+    I18n.backend.expects(:lookup).returns('Bar')
+    assert_equal 'Bar', I18n.t(:foo)
   end
 
   protected


### PR DESCRIPTION
I added functionality that stores a list of keys which have been cached and deletes those keys from the cache store whenever new translations are stored using #store_translations.

I iterate through and delete the keys because using #clear would kill a ton of non-i18n-related keys when someone hooked their mem_cache_store up to I18n.

Anyway I've never done this before, so let me know if I'm doing something stupid :) Tests in cache_test.

Thanks,
-Mike
