### PR TITLE
Let the virtual machine decide the extension of the file so other rubies can optimize

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -1,6 +1,6 @@
 require 'i18n/version'
 require 'i18n/exceptions'
-require 'i18n/interpolate/ruby.rb'
+require 'i18n/interpolate/ruby'
 
 module I18n
   autoload :Backend, 'i18n/backend'


### PR DESCRIPTION
In the case of MacRuby, the compiled version of the file has the extension *.rbo by convention; taking the file extension away from the require let's the virtual machine choose which to load, preferring the *.rbo over the *.rb.
