### PR TITLE
Array as argument to simple backend

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -11,8 +11,8 @@ module I18n
       # plain Ruby (*.rb) or YAML files (*.yml). See #load_rb and #load_yml
       # for details.
       def load_translations(*filenames)
-        filenames = I18n.load_path.flatten if filenames.empty?
-        filenames.each { |filename| load_file(filename) }
+        filenames = I18n.load_path if filenames.empty?
+        filenames.flatten.each { |filename| load_file(filename) }
       end
 
       # This method receives a locale, a data hash and options for storing translations.

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -42,6 +42,10 @@ class I18nBackendSimpleTest < Test::Unit::TestCase
     assert_equal expected, translations
   end
 
+  test "simple load_translations: given file names as array it does not raise anything" do
+    assert_nothing_raised { I18n.backend.load_translations(["#{locales_dir}/en.rb", "#{locales_dir}/en.yml"]) }
+  end
+
   # storing translations
 
   test "simple store_translations: stores translations, ... no, really :-)" do


### PR DESCRIPTION
Hi, there are situations when file names are passed as array to `load_translations`. So this fix ensures that file names are always flattened.
