### PR TITLE
Update dependency from `sqlite3-ruby` to `sqlite3`

### DIFF
--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.5'
 
   s.add_development_dependency 'activesupport', '~> 3.0.0'
-  s.add_development_dependency 'sqlite3-ruby'
+  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'test_declarative'
 end


### PR DESCRIPTION
When installing `sqlite3-ruby`, the following message is displayed:

```
Hello! The sqlite3-ruby gem has changed it's name to just sqlite3.  Rather than
installing `sqlite3-ruby`, you should install `sqlite3`.  Please update your
dependencies accordingly.

Thanks from the Ruby sqlite3 team!

<3 <3 <3 <3
```

This patch updates the development dependency per the Ruby sqlite3 team's recommendation.
