### PR TITLE
Ruby 1.9 compatibility for placeholder naming

### DIFF
--- a/lib/i18n/core_ext/string/interpolate.rb
+++ b/lib/i18n/core_ext/string/interpolate.rb
@@ -37,8 +37,8 @@ rescue ArgumentError
     alias :interpolate_without_ruby_19_syntax :% # :nodoc:
 
     INTERPOLATION_PATTERN = Regexp.union(
-      /%\{(\w+)\}/,                               # matches placeholders like "%{foo}"
-      /%<(\w+)>(.*?\d*\.?\d*[bBdiouxXeEfgGcps])/  # matches placeholders like "%<foo>.d"
+      /%\{([^\{\}\%]+)\}/,                           # matches placeholders like "%{foo}"
+      /%<([^\>]+)>(.*?\d*\.?\d*[bBdiouxXeEfgGcps])/  # matches placeholders like "%<foo>.d"
     )
 
     INTERPOLATION_PATTERN_WITH_ESCAPE = Regexp.union(

--- a/test/core_ext/string/interpolate_test.rb
+++ b/test/core_ext/string/interpolate_test.rb
@@ -18,12 +18,20 @@ class I18nCoreExtStringInterpolationTest < Test::Unit::TestCase
     assert_equal "Masao Mutoh", "%{first} %{last}" % { :first => 'Masao', :last => 'Mutoh' }
   end
 
+  test "String interpolates a hash argument w/ named placeholders when the names contain special symbols" do
+    assert_equal "Test String", "%{test.test } %{ string|string}" % { :"test.test " => "Test", :" string|string" => "String" }
+  end
+
   test "String interpolates a hash argument w/ named placeholders (reverse order)" do
     assert_equal "Mutoh, Masao", "%{last}, %{first}" % { :first => 'Masao', :last => 'Mutoh' }
   end
 
   test "String interpolates named placeholders with sprintf syntax" do
     assert_equal "10, 43.4", "%<integer>d, %<float>.1f" % {:integer => 10, :float => 43.4}
+  end
+
+  test "String interpolates named placeholders using sprintf syntax when the names contain special symbols" do
+    assert_equal "10, 43.4", "%<in.te.   ger>d, %<flo#at>.1f" % { :"in.te.   ger" => 10, :"flo#at" => 43.4 }
   end
 
   test "String interpolates named placeholders with sprintf syntax, does not recurse" do


### PR DESCRIPTION
Hi there,

I adjusted Regexps a bit to make it comply with interpolation behavior on 1.9. I personally needed to be able to use the dot symbol in the names. Hope this is useful.
