### PR TITLE
Make it possible to change the behaviour/signature of I18n method calls

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -12,7 +12,7 @@ module I18n
   RESERVED_KEYS = [:scope, :default, :separator, :resolve, :object, :fallback, :format, :cascade, :throw, :raise, :rescue_format]
   RESERVED_KEYS_PATTERN = /%\{(#{RESERVED_KEYS.join("|")})\}/
 
-  class << self
+  module Base
     # Gets I18n configuration object.
     def config
       Thread.current[:i18n_config] ||= I18n::Config.new
@@ -327,4 +327,6 @@ module I18n
       exception.is_a?(MissingTranslation) ? exception.message : raise(exception)
     end
   end
+
+  extend Base
 end

--- a/test/api/override_test.rb
+++ b/test/api/override_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class I18nOverrideTest < Test::Unit::TestCase
+  module OverrideInverse
+
+    def translate(*args)
+      super(*args).reverse
+    end
+    alias :t :translate
+
+  end
+
+  module OverrideSignature
+
+    def translate(*args)
+      args.first
+    end
+    alias :t :translate
+
+  end
+
+  def setup
+    I18n.backend = I18n::Backend::Simple.new
+    I18n.extend OverrideInverse
+    super
+  end
+
+  test "make sure modules can overwrite I18n methods" do
+    I18n.backend.store_translations('en', :foo => 'bar')
+
+    assert_equal 'rab', I18n.translate(:foo, :locale => 'en')
+    assert_equal 'rab', I18n.t(:foo, :locale => 'en')
+    assert_equal 'rab', I18n.translate!(:foo, :locale => 'en')
+    assert_equal 'rab', I18n.t!(:foo, :locale => 'en')
+  end
+
+  test "make sure modules can overwrite I18n signature" do
+    assert I18n.translate("Hello", "Welcome message on home page", :tokenize => true) # tr8n example
+  end
+
+end


### PR DESCRIPTION
- Useful for other translation engines that do not want to use the key based syntax (tr8n). 
- Makes it a lot easier to put a cache in front of I18n. 

I got inspired with houw action pack's router handles the different ways of defining routes with the same method. So I used a similar technique.

I think this is a very clean solution to (opt in) changing the behaviour of I18n.
