### PR TITLE
Allow mutually recursive fallback

### DIFF
--- a/lib/i18n/locale/fallbacks.rb
+++ b/lib/i18n/locale/fallbacks.rb
@@ -82,10 +82,10 @@ module I18n
 
       protected
 
-      def compute(tags, include_defaults = true)
+      def compute(tags, include_defaults = true, exclude = [])
         result = Array(tags).collect do |tag|
-          tags = I18n::Locale::Tag.tag(tag).self_and_parents.map! { |t| t.to_sym }
-          tags.each { |_tag| tags += compute(@map[_tag]) if @map[_tag] }
+          tags = I18n::Locale::Tag.tag(tag).self_and_parents.map! { |t| t.to_sym } - exclude
+          tags.each { |_tag| tags += compute(@map[_tag], false, exclude + tags) if @map[_tag] }
           tags
         end.flatten
         result.push(*defaults) if include_defaults

--- a/test/locale/fallbacks_test.rb
+++ b/test/locale/fallbacks_test.rb
@@ -121,4 +121,16 @@ class I18nFallbacksComputationTest < Test::Unit::TestCase
   test "with a mapping :de => :en, :he => :en defined it [:he, :en] for :de" do
     assert_equal [:he, :"en-US", :en], @fallbacks[:he]
   end
+
+  # Test allowing mappings that fallback to each other
+
+  test "with :no => :nb, :nb => :no defined :no returns [:no, :nb, :en-US, :en]" do
+    @fallbacks.map(:no => :nb, :nb => :no)
+    assert_equal [:no, :nb, :"en-US", :en], @fallbacks[:no]
+  end
+
+  test "with :no => :nb, :nb => :no defined :nb returns [:nb, :no, :en-US, :en]" do
+    @fallbacks.map(:no => :nb, :nb => :no)
+    assert_equal [:nb, :no, :"en-US", :en], @fallbacks[:nb]
+  end
 end


### PR DESCRIPTION
Where translations are drawn from different sources which may be using
different codes for the same language it can be useful to have mappings
where two codes fallback to each other.

This patch allows that by ensuring that the recursion in the computation
of the mapping terminates instead of running out of stack.
