### PR TITLE
Patch for issue #88: Add filename info to exception message if YAML.load_file fails

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -169,6 +169,9 @@ module I18n
         # toplevel keys.
         def load_yml(filename)
           YAML.load_file(filename)
+        rescue Exception => ex
+          ex.message.insert(0, "Error loading '#{filename}': ")
+          raise ex
         end
     end
   end

--- a/test/backend/base_test.rb
+++ b/test/backend/base_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class I18nBackendBaseTest < Test::Unit::TestCase
+  include I18n::Backend::Base
+
+  test "if YAML.load_file raises an exception, filepath info is prepended to the exception message" do
+    invalid_file = "#{locales_dir}/invalid/syntax.yml"
+    exception = assert_raise(Psych::SyntaxError) { load_translations(invalid_file) }
+    assert_match(/^Error loading/, exception.message)
+    assert_match(Regexp.new(File.expand_path(invalid_file)), exception.message)
+    assert_match(/couldn't parse YAML/, exception.message)
+  end
+end

--- a/test/test_data/locales/invalid/syntax.yml
+++ b/test/test_data/locales/invalid/syntax.yml
@@ -1,0 +1,3 @@
+en:
+  foo:
+    bar: baz:


### PR DESCRIPTION
This augments the error message from any YAML parser, and makes it much easier to debug i18n syntax errors. Otherwise, there's no way of knowing which translation file contains the error.
### Before:

```
Psych::SyntaxError: couldn't parse YAML at line 16 column 14
from /web/tt/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/psych.rb:148:in `parse'
...
```
### After:

```
Psych::SyntaxError: Error loading '/home/username/src/rails/application/config/locales/en-US_application.yml': couldn't parse YAML at line 16 column 14
from /web/tt/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/psych.rb:148:in `parse'
...
```
