### PR TITLE
Fixed French pluralization rule

### DIFF
--- a/test/test_data/locales/plurals.rb
+++ b/test/test_data/locales/plurals.rb
@@ -27,7 +27,7 @@
   :fi => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } },
   :fil => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| [0, 1].include?(n) ? :one : :other } } } },
   :fo => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } },
-  :fr => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n && n != 2 ? :one : :other } } } },
+  :fr => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| (0...2).include?(n) ? :one : :other } } } },
   :fur => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } },
   :fy => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } },
   :ga => { :i18n => { :plural => { :keys => [:one, :two, :other], :rule => lambda { |n| n == 1 ? :one : n == 2 ? :two : :other } } } },


### PR DESCRIPTION
According to Unicode standardization (http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html) the French pluralization rule should be as follows:

one → n within 0..2 and n is not 2;
other → everything else
