### PR TITLE
Fixed I18n::Backend::Base.localize to return the correct date format for %p

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -62,7 +62,7 @@ module I18n
           when '%A' then I18n.t(:"date.day_names",                       :locale => locale, :format => format)[object.wday]
           when '%b' then I18n.t(:"date.abbr_month_names",                :locale => locale, :format => format)[object.mon]
           when '%B' then I18n.t(:"date.month_names",                     :locale => locale, :format => format)[object.mon]
-          when '%p' then I18n.t(:"time.#{object.hour < 12 ? :am : :pm}", :locale => locale, :format => format) if object.respond_to? :hour
+          when '%p' then I18n.t(:"time.#{object.hour < 12 ? :AM : :PM}", :locale => locale, :format => format) if object.respond_to? :hour
           end
         end
 


### PR DESCRIPTION
This translates `%p` into the upper-cased abbreviated meridia, 'PM' and 'AM' not 'pm' and 'am'.
If a case needs to be added for `%P`, let me know and I will add that in.
