### PR TITLE
I18n.l(nil) now returns nil

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -231,6 +231,7 @@ module I18n
 
     # Localizes certain objects, such as dates and numbers to local formatting.
     def localize(object, options = {})
+      return nil if object.nil?
       locale = options.delete(:locale) || config.locale
       format = options.delete(:format) || :default
       config.backend.localize(locale, object, format, options)

--- a/lib/i18n/tests/localization/date.rb
+++ b/lib/i18n/tests/localization/date.rb
@@ -44,8 +44,8 @@ module I18n
           assert_nothing_raised { I18n.l(@date, :format => '%x') }
         end
 
-        test "localize Date: given nil it raises I18n::ArgumentError" do
-          assert_raise(I18n::ArgumentError) { I18n.l(nil) }
+        test "localize Date: given nil it returns nil" do
+          assert_nil I18n.l(nil)
         end
 
         test "localize Date: given a plain Object it raises I18n::ArgumentError" do

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -188,7 +188,7 @@ class I18nTest < Test::Unit::TestCase
   end
 
   test "localize given nil raises an I18n::ArgumentError" do
-    assert_raise(I18n::ArgumentError) { I18n.l nil }
+    assert_nil I18n.l(nil)
   end
 
   test "localize givan an Object raises an I18n::ArgumentError" do


### PR DESCRIPTION
Hi,

Is there any specific reason for l(nil) to throw an ArgumentError? If not, I've patched the code to return nil in these cases. This will help a lot in my projects since I localize dates a lot and I always have to nil-check them even though an nil interpolated into an empty string would be fine.

Please let me know if this should be backend-specific and if other pieces of the project rely on l(nil) throwing Exceptions.
