### PR TITLE
Make pluralize pick the :other key if :one is not defined. Fix doc

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -122,17 +122,20 @@ module I18n
           result unless result.is_a?(MissingTranslation)
         end
 
-        # Picks a translation from an array according to English pluralization
-        # rules. It will pick the first translation if count is not equal to 1
-        # and the second translation if it is equal to 1. Other backends can
-        # implement more flexible or complex pluralization rules.
+        PLURALIZATION_KEYS = Hash.new(:other)
+                            .merge!(0 => :zero, 1 => :one)
+        # Picks a translation from a hash using the key :zero,
+        # :one or :other, depending on count.
+        # In case +entry+ has no value for :zero or :one
+        # then :other will be used.
         def pluralize(locale, entry, count)
           return entry unless entry.is_a?(Hash) && count
 
-          key = :zero if count == 0 && entry.has_key?(:zero)
-          key ||= count == 1 ? :one : :other
-          raise InvalidPluralizationData.new(entry, count) unless entry.has_key?(key)
-          entry[key]
+          entry.fetch(PLURALIZATION_KEYS[count]) do
+            entry.fetch(:other) do
+              raise InvalidPluralizationData.new(entry, count)
+            end
+          end
         end
 
         # Interpolates values into a given string.

--- a/lib/i18n/tests/pluralization.rb
+++ b/lib/i18n/tests/pluralization.rb
@@ -15,6 +15,10 @@ module I18n
         assert_equal 'bar', I18n.t(:default => { :one => 'bar' }, :count => 1)
       end
 
+      test "pluralization: given 1 it returns the :other translation if :one is not defined" do
+        assert_equal 'other', I18n.t(:default => { :other => 'other' }, :count => 1)
+      end
+
       test "pluralization: given 2 it returns the :other translation" do
         assert_equal 'bars', I18n.t(:default => { :other => 'bars' }, :count => 2)
       end


### PR DESCRIPTION
I had problems with the following entries:

```
en:
  used_in_pages:
    zero: Not used anywhere
    other: Already in use: %{page_list}
```

I wanted to display `I18n.t(:used_in_pages, page_list: pages.join(', '), count: pages.length)`

Works well, except for `count == 1`, where it raises an error. I made an extra entry for 'one' in my locale, but I see no compelling reason why that should be required.

This pull request changes that. Note that there was no test for that particular case.

It also fixes the documentation which was obsolete.

I believe the implementation is also faster.

Finally, it makes trivial to add entries for `2 => :two`, etc...
Actually, maybe all numbers up to ten should be included to allow for some languages that have different pluarl forms. Anyways, some people could hack it up by modifying the `PLURALIZATION_KEYS` hash.

Thanks
