### PR TITLE
Include the missing key in "missing interpolation argument" errors.

### DIFF
--- a/lib/i18n/backend/interpolation_compiler.rb
+++ b/lib/i18n/backend/interpolation_compiler.rb
@@ -77,7 +77,7 @@ module I18n
         end
 
         def missing_key(key)
-          "raise(MissingInterpolationArgument.new(#{key}, self))"
+          "raise(MissingInterpolationArgument.new(#{key}, {}, self))"
         end
 
         def reserved_key(key)

--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -81,10 +81,10 @@ module I18n
   end
 
   class MissingInterpolationArgument < ArgumentError
-    attr_reader :values, :string
-    def initialize(values, string)
-      @values, @string = values, string
-      super "missing interpolation argument in #{string.inspect} (#{values.inspect} given)"
+    attr_reader :key, :values, :string
+    def initialize(key, values, string)
+      @key, @values, @string = key, values, string
+      super "missing interpolation argument #{key.inspect} in #{string.inspect} (#{values.inspect} given)"
     end
   end
 

--- a/lib/i18n/interpolate/ruby.rb
+++ b/lib/i18n/interpolate/ruby.rb
@@ -21,7 +21,7 @@ module I18n
           '%'
         else
           key = ($1 || $2).to_sym
-          value = values.key?(key) ? values[key] : raise(MissingInterpolationArgument.new(values, string))
+          value = values.key?(key) ? values[key] : raise(MissingInterpolationArgument.new(key, values, string))
           value = value.call(values) if value.respond_to?(:call)
           $3 ? sprintf("%#{$3}", value) : value
         end

--- a/test/i18n/exceptions_test.rb
+++ b/test/i18n/exceptions_test.rb
@@ -54,14 +54,14 @@ class I18nExceptionsTest < Test::Unit::TestCase
   test "MissingInterpolationArgument stores key and string" do
     assert_raise(I18n::MissingInterpolationArgument) { force_missing_interpolation_argument }
     force_missing_interpolation_argument do |exception|
-      # assert_equal :bar, exception.key
+      assert_equal :bar, exception.key
       assert_equal "%{bar}", exception.string
     end
   end
 
   test "MissingInterpolationArgument message contains the missing and given arguments" do
     force_missing_interpolation_argument do |exception|
-      assert_equal 'missing interpolation argument in "%{bar}" ({:baz=>"baz"} given)', exception.message
+      assert_equal 'missing interpolation argument :bar in "%{bar}" ({:baz=>"baz"} given)', exception.message
     end
   end
 


### PR DESCRIPTION
It's a bit annoying to manually compare the passed-in hash to the arguments, so we fixed it. Hope you'll merge.

Some things I noticed:

`test/i18n/exceptions_test.rb` had a commented-out test about including the missing key in an exception accessor. Couldn't figure out from git blame why it was commented out in the first place ("cleanup"), so I restored it.

`backend/interpolation_compiler.rb` did this:

``` ruby
        def missing_key(key)
          "raise(MissingInterpolationArgument.new(#{key}, self))"
        end
```

That looks like forgotten, possibly dead code. Before my pull request, the actual method profile was `values, string`; the key wasn't passed. I just modified it to pass `{}` for values, so it's about as broken as it was, but that class should probably be reviewed.
