### PR TITLE
Add parens to fix parse error in lib/i18n.rb in MagLev

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -12,7 +12,7 @@ module I18n
   RESERVED_KEYS = [:scope, :default, :separator, :resolve, :object, :fallback, :format, :cascade, :throw, :raise, :rescue_format]
   RESERVED_KEYS_PATTERN = /%\{(#{RESERVED_KEYS.join("|")})\}/
 
-  extend Module.new {
+  extend(Module.new {
     # Gets I18n configuration object.
     def config
       Thread.current[:i18n_config] ||= I18n::Config.new
@@ -328,5 +328,5 @@ module I18n
            "(an instance of which is set to I18n.exception_handler by default)."
       exception.is_a?(MissingTranslation) ? exception.message : raise(exception)
     end
-  }
+  })
 end


### PR DESCRIPTION
This is a fix for Issue 168:  https://github.com/svenfuchs/i18n/issues/168

Currently MagLev throws an error while parsing lib/i18n.rb.

`ERROR 2702 , a RubyParseError occurred (error 2702), 
/Users/johnnyt/.rvm/gems/maglev-head/gems/i18n-0.6.1/lib/i18n.rb:28: syntax error,
unexpected kDO_BLOCK  expecting EOF end-of-file 
unexpected EOF at line 332 (SyntaxError)`

I found that adding parens for the 'extend' method fixes the parse error.
