### PR TITLE
Fix subtree support in I18n::Backend::KeyValue

### DIFF
--- a/lib/i18n/backend/key_value.rb
+++ b/lib/i18n/backend/key_value.rb
@@ -66,7 +66,7 @@ module I18n
             case value
             when Hash
               if @subtrees && (old_value = @store[key])
-                old_value = ActiveSupport::JSON.decode(old_value)
+                old_value = ActiveSupport::JSON.decode(old_value)[0]
                 value = old_value.deep_symbolize_keys.deep_merge!(value) if old_value.is_a?(Hash)
               end
             when Proc


### PR DESCRIPTION
It looks like arrays were enforced on `I18n::Backend::KeyValue` about a year ago (see https://github.com/svenfuchs/i18n/commit/e2b0fe4c9bbcf473caedf711e018843f6765b676) but this appears to have broken subtree support. 

Take a look:

``` ruby
backend = I18n::Backend::KeyValue.new(Hash.new,true) # explicitly enable subtrees
backend.store_translations :en, { :foo => { :bar => 'bar' } }
backend.store_translations :en, { :foo => { :baz => 'baz' } }
backend.send :lookup, :en, :foo # => {:baz=>"baz"}
```

As you can see, we expect a lookup on `:foo` to return the subtree, i.e. `{:foo=>{:bar=>"bar", :baz=>"baz"}}`, but it doesn't :cry:
