### PR TITLE
Preventing transliterator constant from being modified for concurrency concerns

### DIFF
--- a/lib/i18n/backend/transliterator.rb
+++ b/lib/i18n/backend/transliterator.rb
@@ -67,11 +67,11 @@ module I18n
           "ů"=>"u", "Ű"=>"U", "ű"=>"u", "Ų"=>"U", "ų"=>"u", "Ŵ"=>"W", "ŵ"=>"w",
           "Ŷ"=>"Y", "ŷ"=>"y", "Ÿ"=>"Y", "Ź"=>"Z", "ź"=>"z", "Ż"=>"Z", "ż"=>"z",
           "Ž"=>"Z", "ž"=>"z"
-        }
+        }.freeze
 
         def initialize(rule = nil)
           @rule = rule
-          add DEFAULT_APPROXIMATIONS
+          add DEFAULT_APPROXIMATIONS.dup
           add rule if rule
         end
 

--- a/test/backend/transliterator_test.rb
+++ b/test/backend/transliterator_test.rb
@@ -79,4 +79,8 @@ class I18nBackendTransliterator < Test::Unit::TestCase
     assert_not_equal "ue", transliterator.transliterate(char)
   end
 
+  test "DEFAULT_APPROXIMATIONS is frozen to prevent concurrency issues" do
+    assert I18n::Backend::Transliterator::HashTransliterator::DEFAULT_APPROXIMATIONS.frozen?
+  end
+
 end


### PR DESCRIPTION
During #initialize, DEFAULT_APPROXIMATIONS is added to approximations. The behavior of #add, though, will delete from the hash in order to stringify each value. When running a multithreaded application, the state of DEFAULT_APPROXIMATIONS will be in flux between threads leading to errors.
