### PR TITLE
Fetch dependencies from rubygems using secure https.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     mocha (0.9.9)
       rake

--- a/ci/Gemfile.no-rails
+++ b/ci/Gemfile.no-rails
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'mocha'
 gem 'test_declarative'

--- a/ci/Gemfile.rails-2.3.x
+++ b/ci/Gemfile.rails-2.3.x
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'activesupport', '~> 2.3'
 gem 'sqlite3-ruby'

--- a/ci/Gemfile.rails-3.x
+++ b/ci/Gemfile.rails-3.x
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'activesupport', '~> 3.0.0'
 gem 'sqlite3-ruby'


### PR DESCRIPTION
Replaces deprecated `:rubygems` source with `https://rubygems.org`
