### PR TITLE
Return meridian in correct case.

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -56,13 +56,14 @@ module I18n
         end
 
         # format = resolve(locale, object, format, options)
-        format = format.to_s.gsub(/%[aAbBp]/) do |match|
+        format = format.to_s.gsub(/%[aAbBpP]/) do |match|
           case match
           when '%a' then I18n.t(:"date.abbr_day_names",                  :locale => locale, :format => format)[object.wday]
           when '%A' then I18n.t(:"date.day_names",                       :locale => locale, :format => format)[object.wday]
           when '%b' then I18n.t(:"date.abbr_month_names",                :locale => locale, :format => format)[object.mon]
           when '%B' then I18n.t(:"date.month_names",                     :locale => locale, :format => format)[object.mon]
-          when '%p' then I18n.t(:"time.#{object.hour < 12 ? :am : :pm}", :locale => locale, :format => format) if object.respond_to? :hour
+          when '%p' then I18n.t(:"time.#{object.hour < 12 ? :am : :pm}", :locale => locale, :format => format).upcase if object.respond_to? :hour
+          when '%P' then I18n.t(:"time.#{object.hour < 12 ? :am : :pm}", :locale => locale, :format => format).downcase if object.respond_to? :hour
           end
         end
 

--- a/lib/i18n/tests/localization/date_time.rb
+++ b/lib/i18n/tests/localization/date_time.rb
@@ -43,8 +43,13 @@ module I18n
         end
 
         test "localize DateTime: given a meridian indicator format it returns the correct meridian indicator" do
-          assert_equal 'am', I18n.l(@datetime, :format => '%p', :locale => :de)
-          assert_equal 'pm', I18n.l(@other_datetime, :format => '%p', :locale => :de)
+          assert_equal 'AM', I18n.l(@datetime, :format => '%p', :locale => :de)
+          assert_equal 'PM', I18n.l(@other_datetime, :format => '%p', :locale => :de)
+        end
+
+        test "localize DateTime: given a meridian indicator format it returns the correct meridian indicator in downcase" do
+          assert_equal 'am', I18n.l(@datetime, :format => '%P', :locale => :de)
+          assert_equal 'pm', I18n.l(@other_datetime, :format => '%P', :locale => :de)
         end
 
         test "localize DateTime: given an unknown format it does not fail" do

--- a/lib/i18n/tests/localization/time.rb
+++ b/lib/i18n/tests/localization/time.rb
@@ -43,8 +43,13 @@ module I18n
         end
 
         test "localize Time: given a meridian indicator format it returns the correct meridian indicator" do
-          assert_equal 'am', I18n.l(@time, :format => '%p', :locale => :de)
-          assert_equal 'pm', I18n.l(@other_time, :format => '%p', :locale => :de)
+          assert_equal 'AM', I18n.l(@time, :format => '%p', :locale => :de)
+          assert_equal 'PM', I18n.l(@other_time, :format => '%p', :locale => :de)
+        end
+
+        test "localize Time: given a meridian indicator format it returns the correct meridian indicator in upcase" do
+          assert_equal 'am', I18n.l(@time, :format => '%P', :locale => :de)
+          assert_equal 'pm', I18n.l(@other_time, :format => '%P', :locale => :de)
         end
 
         test "localize Time: given an unknown format it does not fail" do


### PR DESCRIPTION
According the format of meridians http://apidock.com/ruby/Time/strftime are 

```
%P - Meridian indicator, lowercase (``am'' or ``pm'')
%p - Meridian indicator, uppercase (``AM'' or ``PM'')
```

Currently it was always `am` or `pm`.

```
I18n.l Time.now, format: '%p' # => Returns 'am' or 'pm'
```
