### PR TITLE
Test against Rubinius 19-mode too on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - ree
-  - rbx
+  - rbx-18mode
+  - rbx-19mode
   - jruby


### PR DESCRIPTION
Rubinius 19-mode now passes all tests thanks to recent commits.
Please note that until a new Rubinius build gets pushed, changes won't be visible.
