### PR TITLE
Fix an issue with setting I18n.config.enforce_available_locales

### DIFF
--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -111,7 +111,7 @@ module I18n
     # [Deprecated] this will default to true in the future
     # Defaults to nil so that it triggers the deprecation warning
     def enforce_available_locales
-      @@enforce_available_locales ||= nil
+      defined?(@@enforce_available_locales) ? @@enforce_available_locales : nil
     end
 
     def enforce_available_locales=(enforce_available_locales)

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -353,4 +353,13 @@ class I18nTest < Test::Unit::TestCase
       I18n.config.enforce_available_locales = false
     end
   end
+
+  test "I18n.enforce_available_locales config can be set to false" do
+    begin
+      I18n.config.enforce_available_locales = false
+      assert_equal false, I18n.config.enforce_available_locales
+    ensure
+      I18n.config.enforce_available_locales = false
+    end
+  end
 end


### PR DESCRIPTION
currently setting this config to false will not stick due to
the memoize overwriting it back to nil. this probaly works ok
in many circumstances because of falsy nil, but annoyingly it
does not prevent the deprecation warning that comes along
with having the setting unconfigured.
