### PR TITLE
Add .po file encoding support (#115).

### DIFF
--- a/lib/i18n/backend/gettext.rb
+++ b/lib/i18n/backend/gettext.rb
@@ -34,7 +34,7 @@ module I18n
         end
 
         def parse(filename)
-          GetText::PoParser.new.parse(::File.read(filename), PoData.new)
+          GetText::PoParser.new.parse_file(filename, PoData.new)
         end
 
         def normalize(locale, data)


### PR DESCRIPTION
GetText::PoParser#parse_file taken from upstream GetText (https://github.com/ruby-gettext/gettext/commit/ff472faae25e9e75df7ce93f8e40c87f4ca1cc30). However, it might be worth of updating entire  file.
