### PR TITLE
Fix instance variable not defined warnings due to added deprecations

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -358,8 +358,8 @@ module I18n
     end
 
     def handle_enforce_available_locales_deprecation
-      if config.enforce_available_locales.nil? && !@unenforced_available_locales_deprecation
-        $stderr.puts "[deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message." 
+      if config.enforce_available_locales.nil? && !defined?(@unenforced_available_locales_deprecation)
+        $stderr.puts "[deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message."
         @unenforced_available_locales_deprecation = true
       end
     end

--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -13,7 +13,7 @@ module I18n
           # TODO: this block is to be replaced by `exception.message` when
           # rescue_format is removed
           if options[:rescue_format] == :html
-            if @rescue_format_deprecation
+            if !defined?(@rescue_format_deprecation)
               $stderr.puts "[DEPRECATED] I18n's :recue_format option will be removed from a future release. All exception messages will be plain text. If you need the exception handler to return an html format please set or pass a custom exception handler."
               @rescue_format_deprecation = true
             end

--- a/test/i18n/exceptions_test.rb
+++ b/test/i18n/exceptions_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class I18nExceptionsTest < Test::Unit::TestCase
   def test_invalid_locale_stores_locale
     force_invalid_locale
-  rescue I18n::ArgumentError => e
+  rescue I18n::ArgumentError => exception
     assert_nil exception.locale
   end
 


### PR DESCRIPTION
Also fix the `rescue_format` deprecation, it seems it was never being triggered because it was checking for the existence of a not yet defined variable.

---

On a side note, I believe tests that rely on [`force_invalid_locale`](https://github.com/carlosantoniodasilva/i18n/blob/3d039354e36005a1829e015dc7bf37f865529a35/test/i18n/exceptions_test.rb#L87-L91) are broken, because the [locale option will never be "invalid"](https://github.com/carlosantoniodasilva/i18n/blob/3d039354e36005a1829e015dc7bf37f865529a35/lib/i18n.rb#L147) since it's going to use the default locale instead, thus no exception is raised.

I can work on a fix for that later if you want, after finishing up a couple things related to I18n deprecations in Rails, just let me know.
