### PR TITLE
I18n.locale= doesn't care about junk values?

### DIFF
--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -9,7 +9,7 @@ module I18n
     # Sets the current locale pseudo-globally, i.e. in the Thread.current hash.
     def locale=(locale)
       I18n.enforce_available_locales!(locale)
-      @locale = locale.to_sym rescue nil
+      @locale = locale && locale.to_sym
     end
 
     # Returns the current backend. Defaults to +Backend::Simple+.
@@ -30,7 +30,7 @@ module I18n
     # Sets the current default locale. Used to set a custom default locale.
     def default_locale=(locale)
       I18n.enforce_available_locales!(locale)
-      @@default_locale = locale.to_sym rescue nil
+      @@default_locale = locale && locale.to_sym
     end
 
     # Returns an array of locales for which translations are available.

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -37,6 +37,10 @@ class I18nTest < Test::Unit::TestCase
     end
   end
 
+  test "default_locale= doesn't ignore junk" do
+    assert_raise(NoMethodError) { I18n.default_locale = Class }
+  end
+
   test "raises an I18n::InvalidLocale exception when setting an unavailable default locale" do
     begin
       I18n.config.enforce_available_locales = true
@@ -55,6 +59,10 @@ class I18nTest < Test::Unit::TestCase
     assert_equal :de, I18n.locale
     assert_equal :de, Thread.current[:i18n_config].locale
     I18n.locale = :en
+  end
+  
+  test "locale= doesn't ignore junk" do
+    assert_raise(NoMethodError) { I18n.locale = Class }
   end
   
   test "raises an I18n::InvalidLocale exception when setting an unavailable locale" do


### PR DESCRIPTION
The following code runs, surprisingly, with no exceptions:

``` ruby
I18n.locale = ["random", "array"]
I18n.locale = Class
I18n.locale = File.new("/dev/null")
```

The cause of this is `rescue nil`. What was the original intent with it? The troubling commit b2ae8dec dates back 4 years ago.

``` ruby
@locale = locale.to_sym rescue nil
```

I've made a pull request that makes it handle only nils. Also, it doesn't swallow any errors produced by to_sym anymore.
