### PR TITLE
Improve performance on enforce_available_locales!

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -275,7 +275,7 @@ module I18n
     # Returns false otherwise.
     # Compare with Strings as `locale` may be coming from user input
     def locale_available?(locale)
-      I18n.available_locales.map(&:to_s).include?(locale.to_s)
+      I18n.config.available_locales_set.include?(locale)
     end
 
     # Raises an InvalidLocale exception when the passed locale is not

--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -41,10 +41,17 @@ module I18n
       @@available_locales || backend.available_locales
     end
 
+    def available_locales_set
+      @@available_locales_set ||= available_locales.inject(Set.new) do |set, locale|
+        set << locale.to_s << locale.to_sym
+      end
+    end
+
     # Sets the available locales.
     def available_locales=(locales)
       @@available_locales = Array(locales).map { |locale| locale.to_sym }
       @@available_locales = nil if @@available_locales.empty?
+      @@available_locales_set = nil
     end
 
     # Returns the current default scope separator. Defaults to '.'

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -56,7 +56,7 @@ class I18nTest < Test::Unit::TestCase
     assert_equal :de, Thread.current[:i18n_config].locale
     I18n.locale = :en
   end
-  
+
   test "raises an I18n::InvalidLocale exception when setting an unavailable locale" do
     begin
       I18n.config.enforce_available_locales = true
@@ -213,6 +213,23 @@ class I18nTest < Test::Unit::TestCase
     ensure
       I18n.config.enforce_available_locales = false
     end
+  end
+
+  test "available_locales can be replaced at runtime" do
+    begin
+      I18n.config.enforce_available_locales = true
+      assert_raise(I18n::InvalidLocale) { I18n.t(:foo, :locale => 'klingon') }
+      old_locales, I18n.config.available_locales = I18n.config.available_locales, [:klingon]
+      I18n.t(:foo, :locale => 'klingon')
+    ensure
+      I18n.config.enforce_available_locales = false
+      I18n.config.available_locales = old_locales
+    end
+  end
+
+  test "available_locales_set should return a set" do
+    assert_equal Set, I18n.config.available_locales_set.class
+    assert_equal (I18n.config.available_locales.size * 2), I18n.config.available_locales_set.size
   end
 
   test "exists? given an existing key will return true" do


### PR DESCRIPTION
Cache the available_locales in a local Set, so we can lookup, and check for inclusions faster.
[fixes #230]

review @carlosantoniodasilva
