### PR TITLE
Fix error when including Fallbacks on non-Simple backend

### DIFF
--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -40,10 +40,13 @@ module I18n
 
         options[:fallback] = true
         I18n.fallbacks[locale].each do |fallback|
-          next unless translations.keys.include?(fallback)
-          catch(:exception) do
-            result = super(fallback, key, options)
-            return result unless result.nil?
+          begin
+            catch(:exception) do
+              result = super(fallback, key, options)
+              return result unless result.nil?
+            end
+          rescue I18n::InvalidLocale
+            # we do nothing when the locale is invalid, as this is a fallback anyways.
           end
         end
         options.delete(:fallback)

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -126,10 +126,21 @@ class I18nBackendFallbacksWithChainTest < I18n::TestCase
   def setup
     backend = Backend.new
     backend.store_translations(:de, :foo => 'FOO')
+    backend.store_translations(:'pt-BR', :foo => 'Baz in :pt-BR')
     I18n.backend = I18n::Backend::Chain.new(I18n::Backend::Simple.new, backend)
+    I18n.backend.class.send(:include, I18n::Backend::Fallbacks)
   end
 
   test "falls back from de-DE to de when there is no translation for de-DE available" do
     assert_equal 'FOO', I18n.t(:foo, :locale => :'de-DE')
+  end
+
+  test "should not raise error when enforce_available_locales is true, :'pt' is missing and default is a Symbol" do
+    I18n.enforce_available_locales = true
+    begin
+      assert_equal 'Foo', I18n.t(:'model.attrs.foo', :locale => :'pt-BR', :default => [:'attrs.foo', "Foo"])
+    ensure
+      I18n.enforce_available_locales = false
+    end
   end
 end


### PR DESCRIPTION
Commit 12aa0f0d0fc1822d6825d81bb9cdfdc4eb325dfd introduced a bug, where
if `Fallbacks` module is included in a class that doesnt define
`translations` the code would fail. This is a pretty common
scenario, for instance when the backend is a `Chain`. Also this was
pretty common case to fail in rails, as its include Fallbacks in the
I18n.backend, like this:

```
I18n.backend.class.send(:include, I18n::Backend::Fallbacks)
```

This stops using the `translations` method in the fallbacks, and instead
ignores `I18n::InvalidLocale` errors.

[fixes #238]
[fixes #258]
[fixes #259]

review @carlosantoniodasilva
