### PR TITLE
add minitest to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 gem 'mocha'
 gem 'test_declarative'
 gem 'rake'
+gem 'minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     metaclass (0.0.4)
+    minitest (5.3.5)
     mocha (1.0.0)
       metaclass (~> 0.0.1)
     rake (10.3.1)
@@ -18,6 +19,7 @@ PLATFORMS
 
 DEPENDENCIES
   i18n!
+  minitest
   mocha
   rake
   test_declarative


### PR DESCRIPTION
Neither test/unit or minitest are in trunk Ruby (right now), so we need to specify the gem dependencies.
