### PR TITLE
add test pattern to the Rakefile so all tests are run

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,8 @@ task :default => [:test]
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   t.libs << 'test'
-  t.pattern = "#{File.dirname(__FILE__)}/test/all.rb"
+  dir = File.dirname(__FILE__)
+  t.pattern = "#{dir}/**/*_test.rb"
   t.verbose = true
   t.warning = true
 end

--- a/test/all.rb
+++ b/test/all.rb
@@ -1,8 +1,0 @@
-# encoding: utf-8
-
-dir = File.dirname(__FILE__)
-$LOAD_PATH.unshift(dir)
-
-Dir["#{dir}/**/*_test.rb"].sort.each do |file|
-  require file.sub(/^#{dir}\/(.*)\.rb$/, '\1')
-end


### PR DESCRIPTION
If we set the path pattern correctly in the Rakefile, then we can rm the `all.rb` file.
