### PR TITLE
fix test failure with seed 24594

### DIFF
--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -124,11 +124,17 @@ class I18nBackendFallbacksWithChainTest < I18n::TestCase
   end
 
   def setup
+    @old_backend = I18n.backend
     backend = Backend.new
     backend.store_translations(:de, :foo => 'FOO')
     backend.store_translations(:'pt-BR', :foo => 'Baz in :pt-BR')
-    I18n.backend = I18n::Backend::Chain.new(I18n::Backend::Simple.new, backend)
-    I18n.backend.class.send(:include, I18n::Backend::Fallbacks)
+    klass = Class.new(I18n::Backend::Chain)
+    klass.send :include, I18n::Backend::Fallbacks
+    I18n.backend = klass.new(I18n::Backend::Simple.new, backend)
+  end
+
+  def teardown
+    I18n.backend = @old_backend
   end
 
   test "falls back from de-DE to de when there is no translation for de-DE available" do


### PR DESCRIPTION
i18n tests don't seem to stand up to test randomization.  This fixes one case.  Before this patch, if you run the tests like this:

```
$ TESTOPTS='--seed=24594' bundle exec rake test
```

They will fail.  This patch fixes them by testing a subclass of `I18n::Backend::Chain` which lets us avoid mutating the class by including `I18n::Backend::Fallbacks`.
