### PR TITLE
fix for reseting available locales Cache on load_path changes

### DIFF
--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -55,7 +55,7 @@ module I18n
     def available_locales=(locales)
       @@available_locales = Array(locales).map { |locale| locale.to_sym }
       @@available_locales = nil if @@available_locales.empty?
-      @@available_locales_set = nil
+      reset_available_locales_set
     end
 
     # Returns the current default scope separator. Defaults to '.'
@@ -110,14 +110,14 @@ module I18n
     # register translation files like this:
     #   I18n.load_path << 'path/to/locale/en.yml'
     def load_path
-      @@available_locales_set = nil      
+      reset_available_locales_set
       @@load_path ||= []
     end
 
     # Sets the load path instance. Custom implementations are expected to
     # behave like a Ruby Array.
     def load_path=(load_path)
-      @@available_locales_set = nil
+      reset_available_locales_set
       @@load_path = load_path
     end
 
@@ -129,6 +129,12 @@ module I18n
 
     def enforce_available_locales=(enforce_available_locales)
       @@enforce_available_locales = enforce_available_locales
+    end
+
+    private
+
+    def reset_available_locales_set
+      @@available_locales_set = nil
     end
   end
 end

--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -110,12 +110,14 @@ module I18n
     # register translation files like this:
     #   I18n.load_path << 'path/to/locale/en.yml'
     def load_path
+      @@available_locales_set = nil      
       @@load_path ||= []
     end
 
     # Sets the load path instance. Custom implementations are expected to
     # behave like a Ruby Array.
     def load_path=(load_path)
+      @@available_locales_set = nil
       @@load_path = load_path
     end
 

--- a/test/i18n/load_path_test.rb
+++ b/test/i18n/load_path_test.rb
@@ -30,5 +30,12 @@ class I18nLoadPathTest < I18n::TestCase
   test "adding arrays of filenames to the load path does not break locale loading" do
     I18n.load_path << Dir[locales_dir + '/*.{rb,yml}']
     assert_equal "baz", I18n.t(:'foo.bar')
+    # should include other locales
+    assert_equal true, I18n.config.available_locales.include?(:pt)
+  end
+
+  test "available locale set reset after changing load path, should include pt" do
+    I18n.load_path = Dir[locales_dir + '/*.{rb,yml}']
+    assert_equal true,I18n.config.available_locales.include?(:pt)
   end
 end

--- a/test/test_data/locales/pt.rb
+++ b/test/test_data/locales/pt.rb
@@ -1,0 +1,3 @@
+# encoding: utf-8
+
+{ :en => { :fuh => { :bah => "bax" } } }

--- a/test/test_data/locales/pt.yml
+++ b/test/test_data/locales/pt.yml
@@ -1,0 +1,3 @@
+pt:
+  foo:
+    bar: bax


### PR DESCRIPTION
When using simple backend and changing the load_path the locales Cache wasn't updating to show updated available_locales. By "reseting" cache it forces to create a new one whenever load_path is changed.
