### PR TITLE
Add tests to check if each backend can support store/lookup of keys ending in the separator character ("." by default).

### DIFF
--- a/test/backend/key_value_test.rb
+++ b/test/backend/key_value_test.rb
@@ -40,4 +40,10 @@ class I18nBackendKeyValueTest < I18n::TestCase
       I18n.t("foo", :raise => true)
     end
   end
+
+  test "key value store: can store and retrieve a translation which key ends with the escope separator character" do
+    setup_backend!
+    store_translations :'en', :"yyy." => "yyy value"
+    assert_equal("yyy value", I18n.t("yyy."))
+  end
 end if I18n::TestCase.key_value?

--- a/test/backend/memoize_test.rb
+++ b/test/backend/memoize_test.rb
@@ -44,4 +44,10 @@ class I18nBackendMemoizeTest < I18nBackendSimpleTest
     assert I18n.available_locales.include?(:copa)
     assert_equal 1, I18n.backend.spy_calls
   end
+
+  test "memoize: can store and retrieve a translation which key ends with the escope separator character" do
+    store_translations :'en', :"yyy." => "yyy value"
+    assert_equal("yyy value", I18n.t("yyy."))
+  end
+
 end

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -70,6 +70,11 @@ class I18nBackendSimpleTest < I18n::TestCase
     assert_equal Hash[:'en', {:foo => {:bar => 'bar', :baz => 'baz'}}], translations
   end
 
+  test "simple store and lookup: can store and retrieve a translation which key ends with the escope separator character" do
+    store_translations :'en', :"yyy." => "yyy value"
+    assert_equal("yyy value", I18n.t("yyy."))
+  end
+
   # reloading translations
 
   test "simple reload_translations: unloads translations" do


### PR DESCRIPTION
There is an inconsistency about how each backend treats the storage and retrieval of keys ending in the scope separator special character (a dot by default):

**Simple backend:**

```
store_translations :'en', :"yyy." => "yyy value" # Stores { :"yyy." => "yyy value" }
I18n.t("yyy.") # translation missing "en.yyy"
```

Translation misses because the code at https://github.com/svenfuchs/i18n/blob/b5703d7431ecfc1b99409e16c6590448570718ac/lib/i18n.rb#L329 strips the final "." from the key while looking up.

**KeyValue backend:**

```
store_translations :'en', :"yyy." => "yyy value" # Stores { "en.yyy\x01" => "yyy value" }
I18n.t("yyy.") # translation missing "en.yyy."
```

Lookup misses because the code at https://github.com/svenfuchs/i18n/blob/b5703d7431ecfc1b99409e16c6590448570718ac/lib/i18n/backend/flatten.rb#L18 does not scape the final '.' as it does on storing. I have tested this patch to make this backend able to scape the key on lookup as it does on storing:

```
 # This will go at https://github.com/svenfuchs/i18n/blob/b5703d7431ecfc1b99409e16c6590448570718ac/lib/i18n/backend/flatten.rb#L28
 if keys.last.to_s.end_with? separator
   was_a_symbol = keys.last.is_a? Symbol
   keys[keys.count - 1] = escape_default_separator(keys.last)
   keys[keys.count - 1] = keys.last.to_sym if was_a_symbol
 end
```

**Simple with Memoize backend:**

Lookup misses in a similar way than Simple, but the data is inconsistent, because the code on
https://github.com/svenfuchs/i18n/blob/b5703d7431ecfc1b99409e16c6590448570718ac/lib/i18n/backend/memoize.rb#L33 causes this difference in the 'stores':
Memoized 'store' --> `@memoized_lookup = { :en => { :"yyy." => nil } }`
While Simple 'store' contains -->  `@translations = { :en => { :"yyy." => "yyy value" } }`

This is because the lookup code at memoized module (the line linked above) does not strip the last ".", as Simple lookup does.

If someone has some suggestion about how to tackle this and gives me some pointers, I will be happy to contribute. Should this code be refactored as part of the base backend? Also, this tests could be moved to https://github.com/svenfuchs/i18n/blob/master/lib/i18n/tests/lookup.rb so it is not repeated on every backend, but I am not sure about this.
