### PR TITLE
Bugfix chain lookup

### DIFF
--- a/lib/i18n/backend/chain.rb
+++ b/lib/i18n/backend/chain.rb
@@ -46,6 +46,7 @@ module I18n
               translation = backend.translate(locale, key, options)
               if namespace_lookup?(translation, options)
                 namespace = translation.merge(namespace || {})
+                return translation
               elsif !translation.nil?
                 return translation
               end


### PR DESCRIPTION
The backend chain has a bug that causes it to look up all backends even if it in fact has already found the translation. The reason is a missing explicit return from that point. This can result in extremely slow lookups if a key can be found in a local backend like the yml file, but has to be looked up in the database backend as well.
