### PR TITLE
Respect skip_root option of cascade

### DIFF
--- a/lib/i18n/backend/cascade.rb
+++ b/lib/i18n/backend/cascade.rb
@@ -47,7 +47,7 @@ module I18n
           result = super
           return result unless result.nil?
           scope = scope.dup
-        end while (!scope.empty? || !skip_root) && scope.slice!(-step, step)
+        end while scope.slice!(-step, step) && !(skip_root && scope.empty?)
       end
     end
   end

--- a/test/backend/cascade_test.rb
+++ b/test/backend/cascade_test.rb
@@ -34,6 +34,11 @@ class I18nBackendCascadeTest < I18n::TestCase
     assert_raise(I18n::MissingTranslationData) { lookup(:'missing.bar.baz', :raise => true) }
   end
 
+  test "skip_root prevents lookup without scope" do
+    @cascade_options[:skip_root] = true
+    assert_raise(I18n::MissingTranslationData) { lookup(:'missing.foo', :raise => true) }
+  end
+
   test "cascades before evaluating the default" do
     assert_equal 'foo', lookup(:foo, :scope => :missing, :default => 'default')
   end


### PR DESCRIPTION
Maybe I just got the meaning of the skip_root option wrong.
My understanding is that it should skip looking up keys in the root of the locale tree.
So if there is only one translation `foo: 'bar'` it should not be found by

``` ruby
I18n.t :foo, cascade: {skip_root: true}
```

So far the test for skip_root did not have any effect (that i could observe).
The cascade tests also passed with skip_root: true.

I included a test to illustrate my understanding of how skip_root should work.
If that's not the way it's meant to work tests for it should be included or it should be removed entirely.
