### PR TITLE
Drop support of Ruby < 2.3 and Rails < 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 2.0.0
-  - 2.1.10
-  - 2.2.8
   - 2.3.5
   - 2.4.4
   - 2.5.1
@@ -14,9 +11,6 @@ rvm:
 
 gemfile:
   - Gemfile
-  - gemfiles/Gemfile.rails-3.2.x
-  - gemfiles/Gemfile.rails-4.0.x
-  - gemfiles/Gemfile.rails-4.1.x
   - gemfiles/Gemfile.rails-4.2.x
   - gemfiles/Gemfile.rails-5.0.x
   - gemfiles/Gemfile.rails-5.1.x
@@ -25,31 +19,7 @@ gemfile:
 
 matrix:
   exclude:
-    # Rails 5.0 requires Ruby >= 2.2
-    - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.rails-5.0.x
-    - rvm: 2.1.10
-      gemfile: gemfiles/Gemfile.rails-5.0.x
-
-    # Rails 5.1 requires Ruby >= 2.2
-    - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.rails-5.1.x
-    - rvm: 2.1.10
-      gemfile: gemfiles/Gemfile.rails-5.1.x
-
-    # Rails 5.2 requires Ruby >= 2.2
-    - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.rails-5.2.x
-    - rvm: 2.1.10
-      gemfile: gemfiles/Gemfile.rails-5.2.x
-
     # Rails 6+ requires Ruby >= 2.4
-    - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.rails-master
-    - rvm: 2.1.10
-      gemfile: gemfiles/Gemfile.rails-master
-    - rvm: 2.2.8
-      gemfile: gemfiles/Gemfile.rails-master
     - rvm: 2.3.5
       gemfile: gemfiles/Gemfile.rails-master
   allow_failures:

--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.rubyforge_project = '[none]'
   s.required_rubygems_version = '>= 1.3.5'
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.3.0'
 
   s.add_dependency 'concurrent-ruby', '~> 1.0'
 end


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/

https://weblog.rubyonrails.org/2016/6/30/Rails-5-0-final/