### PR TITLE
Remove test files from bundled gem

### DIFF
--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
                      'source_code_uri'   => 'https://github.com/svenfuchs/i18n',
                    }
 
-  s.files        = Dir.glob("{gemfiles,lib,test}/**/**") + %w(README.md MIT-LICENSE)
+  s.files        = Dir.glob("lib/**/*") + %w(README.md MIT-LICENSE)
   s.platform     = Gem::Platform::RUBY
   s.require_path = 'lib'
   s.rubyforge_project = '[none]'


### PR DESCRIPTION
Rubygems doesn't need test files to be bundled with the gem, and they double its size. This PR removes them from the files declared in the gemspec. Not a huge space saving, because this gem is already pretty small, but given that each version is downloaded millions of times hopefully it's worth doing!