### PR TITLE
Fix regression with leading zero keys

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -364,7 +364,7 @@ module I18n
           keys.delete('')
           keys.map! do |k|
             case k
-            when /\A[-+]?\d+\z/ # integer
+            when /\A[-+]?[1-9]\d*\z/ # integer
               k.to_i
             when 'true'
               true

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -24,6 +24,12 @@ class I18nBackendSimpleTest < I18n::TestCase
     assert_equal "Yes", I18n.t('available.1')
   end
 
+  test 'simple backend translate: given integer with a lead zero as a key' do
+    store_translations :en, available: { '01' => 'foo' }
+    assert_equal 'foo', I18n.t(:available)[:'01']
+    assert_equal 'foo', I18n.t('available.01')
+  end
+
   test "simple backend translate: symbolize keys in hash" do
     store_translations :en, nested_hashes_in_array: { hello: "world" }
     assert_equal "world", I18n.t('nested_hashes_in_array.hello')


### PR DESCRIPTION
Fix #456 (https://github.com/ruby-i18n/i18n/issues/456).