### PR TITLE
Fix #localize  return error message if translation data is missing

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -250,14 +250,16 @@ module I18n
         def translate_localization_format(locale, object, format, options)
           format.to_s.gsub(/%[aAbBpP]/) do |match|
             case match
-            when '%a' then I18n.t(:"date.abbr_day_names",                  :locale => locale, :format => format)[object.wday]
-            when '%A' then I18n.t(:"date.day_names",                       :locale => locale, :format => format)[object.wday]
-            when '%b' then I18n.t(:"date.abbr_month_names",                :locale => locale, :format => format)[object.mon]
-            when '%B' then I18n.t(:"date.month_names",                     :locale => locale, :format => format)[object.mon]
-            when '%p' then I18n.t(:"time.#{object.hour < 12 ? :am : :pm}", :locale => locale, :format => format).upcase if object.respond_to? :hour
-            when '%P' then I18n.t(:"time.#{object.hour < 12 ? :am : :pm}", :locale => locale, :format => format).downcase if object.respond_to? :hour
+            when '%a' then I18n.t!(:"date.abbr_day_names",                  :locale => locale, :format => format)[object.wday]
+            when '%A' then I18n.t!(:"date.day_names",                       :locale => locale, :format => format)[object.wday]
+            when '%b' then I18n.t!(:"date.abbr_month_names",                :locale => locale, :format => format)[object.mon]
+            when '%B' then I18n.t!(:"date.month_names",                     :locale => locale, :format => format)[object.mon]
+            when '%p' then I18n.t!(:"time.#{object.hour < 12 ? :am : :pm}", :locale => locale, :format => format).upcase if object.respond_to? :hour
+            when '%P' then I18n.t!(:"time.#{object.hour < 12 ? :am : :pm}", :locale => locale, :format => format).downcase if object.respond_to? :hour
             end
           end
+        rescue MissingTranslationData => e
+          e.message
         end
 
         def pluralization_key(entry, count)

--- a/lib/i18n/tests/localization/date.rb
+++ b/lib/i18n/tests/localization/date.rb
@@ -40,6 +40,10 @@ module I18n
           assert_equal 'Mar', I18n.l(@date, :format => '%b', :locale => :de)
         end
 
+        test "localize Date: given missing translations it returns the correct error message" do
+          assert_equal 'translation missing: fr.date.abbr_month_names', I18n.l(@date, :format => '%b', :locale => :fr)
+        end
+
         test "localize Date: given an unknown format it does not fail" do
           assert_nothing_raised { I18n.l(@date, :format => '%x') }
         end

--- a/lib/i18n/tests/localization/date_time.rb
+++ b/lib/i18n/tests/localization/date_time.rb
@@ -42,6 +42,10 @@ module I18n
           assert_equal 'Mar', I18n.l(@datetime, :format => '%b', :locale => :de)
         end
 
+        test "localize DateTime: given missing translations it returns the correct error message" do
+          assert_equal 'translation missing: fr.date.abbr_month_names', I18n.l(@datetime, :format => '%b', :locale => :fr)
+        end
+
         test "localize DateTime: given a meridian indicator format it returns the correct meridian indicator" do
           assert_equal 'AM', I18n.l(@datetime, :format => '%p', :locale => :de)
           assert_equal 'PM', I18n.l(@other_datetime, :format => '%p', :locale => :de)

--- a/lib/i18n/tests/localization/time.rb
+++ b/lib/i18n/tests/localization/time.rb
@@ -42,6 +42,10 @@ module I18n
           assert_equal 'Mar', I18n.l(@time, :format => '%b', :locale => :de)
         end
 
+        test "localize Time: given missing translations it returns the correct error message" do
+          assert_equal 'translation missing: fr.date.abbr_month_names', I18n.l(@time, :format => '%b', :locale => :fr)
+        end
+
         test "localize Time: given a meridian indicator format it returns the correct meridian indicator" do
           assert_equal 'AM', I18n.l(@time, :format => '%p', :locale => :de)
           assert_equal 'PM', I18n.l(@other_time, :format => '%p', :locale => :de)


### PR DESCRIPTION
If you try to localize a date without needed translations you will get a confusing result:
```ruby
I18n.l(@date, :format => '%b', :locale => :fr) # => "r"
``` 

In that case, I'd expect to get some meaningful error message:
```ruby
I18n.l(@date, :format => '%b', :locale => :fr) # => "translation missing: fr.date.abbr_month_names"
```