### PR TITLE
Update gemspec homepage

### DIFF
--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version      = I18n::VERSION
   s.authors      = ["Sven Fuchs", "Joshua Harvey", "Matt Aimonetti", "Stephan Soller", "Saimon Moore", "Ryan Bigg"]
   s.email        = "rails-i18n@googlegroups.com"
-  s.homepage     = "http://github.com/svenfuchs/i18n"
+  s.homepage     = "http://github.com/ruby-i18n/i18n"
   s.summary      = "New wave Internationalization support for Ruby"
   s.description  = "New wave Internationalization support for Ruby."
   s.license      = "MIT"


### PR DESCRIPTION
The repository has moved to ruby-i18n/i18n so the gemspec should be
correspondingly updated.