### PR TITLE
Add support for uppercased date format directives

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -248,12 +248,16 @@ module I18n
         end
 
         def translate_localization_format(locale, object, format, options)
-          format.to_s.gsub(/%[aAbBpP]/) do |match|
+          format.to_s.gsub(/%(|\^)[aAbBpP]/) do |match|
             case match
             when '%a' then I18n.t!(:"date.abbr_day_names",                  :locale => locale, :format => format)[object.wday]
+            when '%^a' then I18n.t!(:"date.abbr_day_names",                 :locale => locale, :format => format)[object.wday].upcase
             when '%A' then I18n.t!(:"date.day_names",                       :locale => locale, :format => format)[object.wday]
+            when '%^A' then I18n.t!(:"date.day_names",                      :locale => locale, :format => format)[object.wday].upcase
             when '%b' then I18n.t!(:"date.abbr_month_names",                :locale => locale, :format => format)[object.mon]
+            when '%^b' then I18n.t!(:"date.abbr_month_names",               :locale => locale, :format => format)[object.mon].upcase
             when '%B' then I18n.t!(:"date.month_names",                     :locale => locale, :format => format)[object.mon]
+            when '%^B' then I18n.t!(:"date.month_names",                    :locale => locale, :format => format)[object.mon].upcase
             when '%p' then I18n.t!(:"time.#{object.hour < 12 ? :am : :pm}", :locale => locale, :format => format).upcase if object.respond_to? :hour
             when '%P' then I18n.t!(:"time.#{object.hour < 12 ? :am : :pm}", :locale => locale, :format => format).downcase if object.respond_to? :hour
             end

--- a/lib/i18n/tests/localization/date.rb
+++ b/lib/i18n/tests/localization/date.rb
@@ -28,7 +28,7 @@ module I18n
         end
 
         test "localize Date: given a uppercased day name format it returns the correct day name in upcase" do
-          assert_equal 'SAMSTAG', I18n.l(@date, :format => '%^A', :locale => :de)
+          assert_equal 'samstag'.upcase, I18n.l(@date, :format => '%^A', :locale => :de)
         end
 
         test "localize Date: given an abbreviated day name format it returns the correct abbreviated day name" do
@@ -36,7 +36,7 @@ module I18n
         end
 
         test "localize Date: given an abbreviated and uppercased day name format it returns the correct abbreviated day name in upcase" do
-          assert_equal 'SA', I18n.l(@date, :format => '%^a', :locale => :de)
+          assert_equal 'sa'.upcase, I18n.l(@date, :format => '%^a', :locale => :de)
         end
 
         test "localize Date: given a month name format it returns the correct month name" do
@@ -44,7 +44,7 @@ module I18n
         end
 
         test "localize Date: given a uppercased month name format it returns the correct month name in upcase" do
-          assert_equal 'MÄRZ', I18n.l(@date, :format => '%^B', :locale => :de)
+          assert_equal 'märz'.upcase, I18n.l(@date, :format => '%^B', :locale => :de)
         end
 
         test "localize Date: given an abbreviated month name format it returns the correct abbreviated month name" do
@@ -54,11 +54,11 @@ module I18n
 
         test "localize Date: given an abbreviated and uppercased month name format it returns the correct abbreviated month name in upcase" do
           # TODO should be Mrz, shouldn't it?
-          assert_equal 'MAR', I18n.l(@date, :format => '%^b', :locale => :de)
+          assert_equal 'mar'.upcase, I18n.l(@date, :format => '%^b', :locale => :de)
         end
 
         test "localize Date: given a date format with the month name upcased it returns the correct value" do
-          assert_equal '1. MÄRZ 2008', I18n.l(@date, :format => "%-d. %^B %Y", :locale => :de)
+          assert_equal '1. FEBRUAR 2008', I18n.l(::Date.new(2008, 2, 1), :format => "%-d. %^B %Y", :locale => :de)
         end
 
         test "localize Date: given missing translations it returns the correct error message" do

--- a/lib/i18n/tests/localization/date.rb
+++ b/lib/i18n/tests/localization/date.rb
@@ -11,8 +11,7 @@ module I18n
         end
 
         test "localize Date: given the short format it uses it" do
-          # TODO should be Mrz, shouldn't it?
-          assert_equal '01. Mar', I18n.l(@date, :format => :short, :locale => :de)
+          assert_equal '01. Mär', I18n.l(@date, :format => :short, :locale => :de)
         end
 
         test "localize Date: given the long format it uses it" do
@@ -48,13 +47,11 @@ module I18n
         end
 
         test "localize Date: given an abbreviated month name format it returns the correct abbreviated month name" do
-          # TODO should be Mrz, shouldn't it?
-          assert_equal 'Mar', I18n.l(@date, :format => '%b', :locale => :de)
+          assert_equal 'Mär', I18n.l(@date, :format => '%b', :locale => :de)
         end
 
         test "localize Date: given an abbreviated and uppercased month name format it returns the correct abbreviated month name in upcase" do
-          # TODO should be Mrz, shouldn't it?
-          assert_equal 'mar'.upcase, I18n.l(@date, :format => '%^b', :locale => :de)
+          assert_equal 'mär'.upcase, I18n.l(@date, :format => '%^b', :locale => :de)
         end
 
         test "localize Date: given a date format with the month name upcased it returns the correct value" do
@@ -71,7 +68,7 @@ module I18n
 
         test "localize Date: does not modify the options hash" do
           options = { :format => '%b', :locale => :de }
-          assert_equal 'Mar', I18n.l(@date, options)
+          assert_equal 'Mär', I18n.l(@date, options)
           assert_equal({ :format => '%b', :locale => :de }, options)
           assert_nothing_raised { I18n.l(@date, options.freeze) }
         end
@@ -110,7 +107,7 @@ module I18n
                 :day_names => %w(Sonntag Montag Dienstag Mittwoch Donnerstag Freitag Samstag),
                 :abbr_day_names => %w(So Mo Di Mi Do Fr  Sa),
                 :month_names => %w(Januar Februar März April Mai Juni Juli August September Oktober November Dezember).unshift(nil),
-                :abbr_month_names => %w(Jan Feb Mar Apr Mai Jun Jul Aug Sep Okt Nov Dez).unshift(nil)
+                :abbr_month_names => %w(Jan Feb Mär Apr Mai Jun Jul Aug Sep Okt Nov Dez).unshift(nil)
               }
             }
           end

--- a/lib/i18n/tests/localization/date.rb
+++ b/lib/i18n/tests/localization/date.rb
@@ -27,17 +27,38 @@ module I18n
           assert_equal 'Samstag', I18n.l(@date, :format => '%A', :locale => :de)
         end
 
+        test "localize Date: given a uppercased day name format it returns the correct day name in upcase" do
+          assert_equal 'SAMSTAG', I18n.l(@date, :format => '%^A', :locale => :de)
+        end
+
         test "localize Date: given an abbreviated day name format it returns the correct abbreviated day name" do
           assert_equal 'Sa', I18n.l(@date, :format => '%a', :locale => :de)
+        end
+
+        test "localize Date: given an abbreviated and uppercased day name format it returns the correct abbreviated day name in upcase" do
+          assert_equal 'SA', I18n.l(@date, :format => '%^a', :locale => :de)
         end
 
         test "localize Date: given a month name format it returns the correct month name" do
           assert_equal 'März', I18n.l(@date, :format => '%B', :locale => :de)
         end
 
+        test "localize Date: given a uppercased month name format it returns the correct month name in upcase" do
+          assert_equal 'MÄRZ', I18n.l(@date, :format => '%^B', :locale => :de)
+        end
+
         test "localize Date: given an abbreviated month name format it returns the correct abbreviated month name" do
           # TODO should be Mrz, shouldn't it?
           assert_equal 'Mar', I18n.l(@date, :format => '%b', :locale => :de)
+        end
+
+        test "localize Date: given an abbreviated and uppercased month name format it returns the correct abbreviated month name in upcase" do
+          # TODO should be Mrz, shouldn't it?
+          assert_equal 'MAR', I18n.l(@date, :format => '%^b', :locale => :de)
+        end
+
+        test "localize Date: given a date format with the month name upcased it returns the correct value" do
+          assert_equal '1. MÄRZ 2008', I18n.l(@date, :format => "%-d. %^B %Y", :locale => :de)
         end
 
         test "localize Date: given missing translations it returns the correct error message" do

--- a/lib/i18n/tests/localization/date_time.rb
+++ b/lib/i18n/tests/localization/date_time.rb
@@ -12,8 +12,7 @@ module I18n
         end
 
         test "localize DateTime: given the short format it uses it" do
-          # TODO should be Mrz, shouldn't it?
-          assert_equal '01. Mar 06:00', I18n.l(@datetime, :format => :short, :locale => :de)
+          assert_equal '01. Mär 06:00', I18n.l(@datetime, :format => :short, :locale => :de)
         end
 
         test "localize DateTime: given the long format it uses it" do
@@ -21,8 +20,7 @@ module I18n
         end
 
         test "localize DateTime: given the default format it uses it" do
-          # TODO should be Mrz, shouldn't it?
-          assert_equal 'Sa, 01. Mar 2008 06:00:00 +0000', I18n.l(@datetime, :format => :default, :locale => :de)
+          assert_equal 'Sa, 01. Mär 2008 06:00:00 +0000', I18n.l(@datetime, :format => :default, :locale => :de)
         end
 
         test "localize DateTime: given a day name format it returns the correct day name" do
@@ -50,13 +48,11 @@ module I18n
         end
 
         test "localize DateTime: given an abbreviated month name format it returns the correct abbreviated month name" do
-          # TODO should be Mrz, shouldn't it?
-          assert_equal 'Mar', I18n.l(@datetime, :format => '%b', :locale => :de)
+          assert_equal 'Mär', I18n.l(@datetime, :format => '%b', :locale => :de)
         end
 
         test "localize DateTime: given an abbreviated and uppercased month name format it returns the correct abbreviated month name in upcase" do
-          # TODO should be Mrz, shouldn't it?
-          assert_equal 'mar'.upcase, I18n.l(@datetime, :format => '%^b', :locale => :de)
+          assert_equal 'mär'.upcase, I18n.l(@datetime, :format => '%^b', :locale => :de)
         end
 
         test "localize DateTime: given a date format with the month name upcased it returns the correct value" do

--- a/lib/i18n/tests/localization/date_time.rb
+++ b/lib/i18n/tests/localization/date_time.rb
@@ -30,7 +30,7 @@ module I18n
         end
 
         test "localize DateTime: given a uppercased day name format it returns the correct day name in upcase" do
-          assert_equal 'SAMSTAG', I18n.l(@datetime, :format => '%^A', :locale => :de)
+          assert_equal 'samstag'.upcase, I18n.l(@datetime, :format => '%^A', :locale => :de)
         end
 
         test "localize DateTime: given an abbreviated day name format it returns the correct abbreviated day name" do
@@ -38,7 +38,7 @@ module I18n
         end
 
         test "localize DateTime: given an abbreviated and uppercased day name format it returns the correct abbreviated day name in upcase" do
-          assert_equal 'SA', I18n.l(@datetime, :format => '%^a', :locale => :de)
+          assert_equal 'sa'.upcase, I18n.l(@datetime, :format => '%^a', :locale => :de)
         end
 
         test "localize DateTime: given a month name format it returns the correct month name" do
@@ -46,7 +46,7 @@ module I18n
         end
 
         test "localize DateTime: given a uppercased month name format it returns the correct month name in upcase" do
-          assert_equal 'MÄRZ', I18n.l(@datetime, :format => '%^B', :locale => :de)
+          assert_equal 'märz'.upcase, I18n.l(@datetime, :format => '%^B', :locale => :de)
         end
 
         test "localize DateTime: given an abbreviated month name format it returns the correct abbreviated month name" do
@@ -56,11 +56,11 @@ module I18n
 
         test "localize DateTime: given an abbreviated and uppercased month name format it returns the correct abbreviated month name in upcase" do
           # TODO should be Mrz, shouldn't it?
-          assert_equal 'MAR', I18n.l(@datetime, :format => '%^b', :locale => :de)
+          assert_equal 'mar'.upcase, I18n.l(@datetime, :format => '%^b', :locale => :de)
         end
 
         test "localize DateTime: given a date format with the month name upcased it returns the correct value" do
-          assert_equal '1. MÄRZ 2008', I18n.l(@datetime, :format => "%-d. %^B %Y", :locale => :de)
+          assert_equal '1. FEBRUAR 2008', I18n.l(::DateTime.new(2008, 2, 1, 6), :format => "%-d. %^B %Y", :locale => :de)
         end
 
         test "localize DateTime: given missing translations it returns the correct error message" do

--- a/lib/i18n/tests/localization/date_time.rb
+++ b/lib/i18n/tests/localization/date_time.rb
@@ -29,17 +29,38 @@ module I18n
           assert_equal 'Samstag', I18n.l(@datetime, :format => '%A', :locale => :de)
         end
 
+        test "localize DateTime: given a uppercased day name format it returns the correct day name in upcase" do
+          assert_equal 'SAMSTAG', I18n.l(@datetime, :format => '%^A', :locale => :de)
+        end
+
         test "localize DateTime: given an abbreviated day name format it returns the correct abbreviated day name" do
           assert_equal 'Sa', I18n.l(@datetime, :format => '%a', :locale => :de)
+        end
+
+        test "localize DateTime: given an abbreviated and uppercased day name format it returns the correct abbreviated day name in upcase" do
+          assert_equal 'SA', I18n.l(@datetime, :format => '%^a', :locale => :de)
         end
 
         test "localize DateTime: given a month name format it returns the correct month name" do
           assert_equal 'März', I18n.l(@datetime, :format => '%B', :locale => :de)
         end
 
+        test "localize DateTime: given a uppercased month name format it returns the correct month name in upcase" do
+          assert_equal 'MÄRZ', I18n.l(@datetime, :format => '%^B', :locale => :de)
+        end
+
         test "localize DateTime: given an abbreviated month name format it returns the correct abbreviated month name" do
           # TODO should be Mrz, shouldn't it?
           assert_equal 'Mar', I18n.l(@datetime, :format => '%b', :locale => :de)
+        end
+
+        test "localize DateTime: given an abbreviated and uppercased month name format it returns the correct abbreviated month name in upcase" do
+          # TODO should be Mrz, shouldn't it?
+          assert_equal 'MAR', I18n.l(@datetime, :format => '%^b', :locale => :de)
+        end
+
+        test "localize DateTime: given a date format with the month name upcased it returns the correct value" do
+          assert_equal '1. MÄRZ 2008', I18n.l(@datetime, :format => "%-d. %^B %Y", :locale => :de)
         end
 
         test "localize DateTime: given missing translations it returns the correct error message" do

--- a/lib/i18n/tests/localization/time.rb
+++ b/lib/i18n/tests/localization/time.rb
@@ -12,8 +12,7 @@ module I18n
         end
 
         test "localize Time: given the short format it uses it" do
-          # TODO should be Mrz, shouldn't it?
-          assert_equal '01. Mar 06:00', I18n.l(@time, :format => :short, :locale => :de)
+          assert_equal '01. Mär 06:00', I18n.l(@time, :format => :short, :locale => :de)
         end
 
         test "localize Time: given the long format it uses it" do
@@ -50,13 +49,11 @@ module I18n
         end
 
         test "localize Time: given an abbreviated month name format it returns the correct abbreviated month name" do
-          # TODO should be Mrz, shouldn't it?
-          assert_equal 'Mar', I18n.l(@time, :format => '%b', :locale => :de)
+          assert_equal 'Mär', I18n.l(@time, :format => '%b', :locale => :de)
         end
 
         test "localize Time: given an abbreviated and uppercased month name format it returns the correct abbreviated month name in upcase" do
-          # TODO should be Mrz, shouldn't it?
-          assert_equal 'mar'.upcase, I18n.l(@time, :format => '%^b', :locale => :de)
+          assert_equal 'mär'.upcase, I18n.l(@time, :format => '%^b', :locale => :de)
         end
 
         test "localize Time: given a date format with the month name upcased it returns the correct value" do

--- a/lib/i18n/tests/localization/time.rb
+++ b/lib/i18n/tests/localization/time.rb
@@ -30,7 +30,7 @@ module I18n
         end
 
         test "localize Time: given a uppercased day name format it returns the correct day name in upcase" do
-          assert_equal 'SAMSTAG', I18n.l(@time, :format => '%^A', :locale => :de)
+          assert_equal 'samstag'.upcase, I18n.l(@time, :format => '%^A', :locale => :de)
         end
 
         test "localize Time: given an abbreviated day name format it returns the correct abbreviated day name" do
@@ -38,7 +38,7 @@ module I18n
         end
 
         test "localize Time: given an abbreviated and uppercased day name format it returns the correct abbreviated day name in upcase" do
-          assert_equal 'SA', I18n.l(@time, :format => '%^a', :locale => :de)
+          assert_equal 'sa'.upcase, I18n.l(@time, :format => '%^a', :locale => :de)
         end
 
         test "localize Time: given a month name format it returns the correct month name" do
@@ -46,7 +46,7 @@ module I18n
         end
 
         test "localize Time: given a uppercased month name format it returns the correct month name in upcase" do
-          assert_equal 'MÄRZ', I18n.l(@time, :format => '%^B', :locale => :de)
+          assert_equal 'märz'.upcase, I18n.l(@time, :format => '%^B', :locale => :de)
         end
 
         test "localize Time: given an abbreviated month name format it returns the correct abbreviated month name" do
@@ -56,11 +56,11 @@ module I18n
 
         test "localize Time: given an abbreviated and uppercased month name format it returns the correct abbreviated month name in upcase" do
           # TODO should be Mrz, shouldn't it?
-          assert_equal 'MAR', I18n.l(@time, :format => '%^b', :locale => :de)
+          assert_equal 'mar'.upcase, I18n.l(@time, :format => '%^b', :locale => :de)
         end
 
         test "localize Time: given a date format with the month name upcased it returns the correct value" do
-          assert_equal '1. MÄRZ 2008', I18n.l(@time, :format => "%-d. %^B %Y", :locale => :de)
+          assert_equal '1. FEBRUAR 2008', I18n.l(::Time.utc(2008, 2, 1, 6, 0), :format => "%-d. %^B %Y", :locale => :de)
         end
 
         test "localize Time: given missing translations it returns the correct error message" do

--- a/lib/i18n/tests/localization/time.rb
+++ b/lib/i18n/tests/localization/time.rb
@@ -29,17 +29,38 @@ module I18n
           assert_equal 'Samstag', I18n.l(@time, :format => '%A', :locale => :de)
         end
 
+        test "localize Time: given a uppercased day name format it returns the correct day name in upcase" do
+          assert_equal 'SAMSTAG', I18n.l(@time, :format => '%^A', :locale => :de)
+        end
+
         test "localize Time: given an abbreviated day name format it returns the correct abbreviated day name" do
           assert_equal 'Sa', I18n.l(@time, :format => '%a', :locale => :de)
+        end
+
+        test "localize Time: given an abbreviated and uppercased day name format it returns the correct abbreviated day name in upcase" do
+          assert_equal 'SA', I18n.l(@time, :format => '%^a', :locale => :de)
         end
 
         test "localize Time: given a month name format it returns the correct month name" do
           assert_equal 'März', I18n.l(@time, :format => '%B', :locale => :de)
         end
 
+        test "localize Time: given a uppercased month name format it returns the correct month name in upcase" do
+          assert_equal 'MÄRZ', I18n.l(@time, :format => '%^B', :locale => :de)
+        end
+
         test "localize Time: given an abbreviated month name format it returns the correct abbreviated month name" do
           # TODO should be Mrz, shouldn't it?
           assert_equal 'Mar', I18n.l(@time, :format => '%b', :locale => :de)
+        end
+
+        test "localize Time: given an abbreviated and uppercased month name format it returns the correct abbreviated month name in upcase" do
+          # TODO should be Mrz, shouldn't it?
+          assert_equal 'MAR', I18n.l(@time, :format => '%^b', :locale => :de)
+        end
+
+        test "localize Time: given a date format with the month name upcased it returns the correct value" do
+          assert_equal '1. MÄRZ 2008', I18n.l(@time, :format => "%-d. %^B %Y", :locale => :de)
         end
 
         test "localize Time: given missing translations it returns the correct error message" do


### PR DESCRIPTION
### Problem

Fixes: https://github.com/ruby-i18n/i18n/issues/463

Certain Ruby uppercased strftime directives are not parsed correctly in `i18n`, namely `%^A`, `%^a`, `%^B`, and `%^b`. These directives will always return the english version of the string. 

#### Before
<img width="454" alt="screen shot 2019-02-11 at 11 36 46 pm" src="https://user-images.githubusercontent.com/26511081/52612073-33a49500-2e56-11e9-98c3-ef9bfcbf6575.png">

### Solution

Added support for the following uppercased date format directives: 
`%^A`, `%^a`, `%^B`, and `%^b`

#### After
<img width="498" alt="screen shot 2019-02-11 at 11 40 56 pm" src="https://user-images.githubusercontent.com/26511081/52612146-85e5b600-2e56-11e9-9c38-95875d3f25cc.png">

cc: @blaszczakphoto @radar 