### PR TITLE
Implement I18n.eager_load!

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -69,6 +69,13 @@ module I18n
       config.backend.reload!
     end
 
+    # Tells the backend to load translations now. Used in situations like the
+    # Rails production environment. Backends can implement whatever strategy
+    # is useful.
+    def eager_load!
+      config.backend.eager_load!
+    end
+
     # Translates, pluralizes and interpolates a given key using a given locale,
     # scope, and default, as well as interpolation values.
     #

--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -95,9 +95,18 @@ module I18n
       end
 
       def reload!
+        eager_load! if eager_loaded?
+      end
+
+      def eager_load!
+        @eager_loaded = true
       end
 
       protected
+
+        def eager_loaded?
+          @eager_loaded ||= false
+        end
 
         # The method which actually looks up for the translation in the store.
         def lookup(locale, key, scope = [], options = EMPTY_HASH)

--- a/lib/i18n/backend/chain.rb
+++ b/lib/i18n/backend/chain.rb
@@ -41,6 +41,10 @@ module I18n
           backends.each { |backend| backend.reload! }
         end
 
+        def eager_load!
+          backends.each { |backend| backend.eager_load! }
+        end
+
         def store_translations(locale, data, options = EMPTY_HASH)
           backends.first.store_translations(locale, data, options)
         end

--- a/lib/i18n/backend/memoize.rb
+++ b/lib/i18n/backend/memoize.rb
@@ -26,6 +26,12 @@ module I18n
         super
       end
 
+      def eager_load!
+        memoized_lookup
+        available_locales
+        super
+      end
+
       protected
 
         def lookup(locale, key, scope = nil, options = EMPTY_HASH)

--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -63,6 +63,11 @@ module I18n
           super
         end
 
+        def eager_load!
+          init_translations unless initialized?
+          super
+        end
+
         def translations(do_init: false)
           # To avoid returning empty translations,
           # call `init_translations`

--- a/test/backend/chain_test.rb
+++ b/test/backend/chain_test.rb
@@ -101,6 +101,12 @@ class I18nBackendChainTest < I18n::TestCase
     assert !@second.initialized?
   end
 
+  test 'should eager load all backends' do
+    I18n.backend.eager_load!
+    assert @first.initialized?
+    assert @second.initialized?
+  end
+
   test 'should be able to get all translations of the first backend' do
     assert_equal I18n.backend.send(:translations),
                  en: {

--- a/test/backend/memoize_test.rb
+++ b/test/backend/memoize_test.rb
@@ -45,6 +45,13 @@ class I18nBackendMemoizeTest < I18nBackendSimpleTest
     assert_equal 1, I18n.backend.spy_calls
   end
 
+  def test_eager_load
+    I18n.eager_load!
+    I18n.backend.spy_calls = 0
+    assert_equal I18n.available_locales, I18n.available_locales
+    assert_equal 0, I18n.backend.spy_calls
+  end
+
   module TestLookup
     def lookup(locale, key, scope = [], options = {})
       keys = I18n.normalize_keys(locale, key, scope, options[:separator])

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -152,6 +152,18 @@ class I18nBackendSimpleTest < I18n::TestCase
     assert_equal false, I18n.backend.initialized?
   end
 
+  test "simple eager_load!: loads the translations" do
+    assert_equal false, I18n.backend.initialized?
+    I18n.backend.eager_load!
+    assert_equal true, I18n.backend.initialized?
+  end
+
+  test "simple reload!: reinitialize the backend if it was previously eager loaded" do
+    I18n.backend.eager_load!
+    I18n.backend.reload!
+    assert_equal true, I18n.backend.initialized?
+  end
+
   test "returns localized string given missing pluralization data" do
     assert_equal 'baz', I18n.t('foo.bar', count: 1)
   end


### PR DESCRIPTION
Depending on the amount of translation keys and locales, loading the translation data can be quite slow (~2s in our case).

Because of this, if you are in a production web app context, you do want to trigger the loading during boot time so that the first user to hit that code path won't be slowed down.

Rails has a convention for this, if your namespace respond to `eager_load!` you can simply add it to `Rails.application.config.eager_load_namespaces` like so `Rails.application.config.eager_load_namespaces << I18n`.
