### PR TITLE
I18n::Backend::Chain#translations should merge from all backends

### DIFF
--- a/lib/i18n/backend/chain.rb
+++ b/lib/i18n/backend/chain.rb
@@ -92,13 +92,13 @@ module I18n
           end
 
           def translations
-            backends.reverse.inject({}) do |h, b|
-              to_merge = b.instance_eval do
+            backends.reverse.each_with_object({}) do |backend, memo|
+              partial_translations = backend.instance_eval do
                 init_translations unless initialized?
                 translations
               end
 
-              h.deep_merge(to_merge)
+              memo.deep_merge!(partial_translations)
             end
           end
 

--- a/lib/i18n/backend/chain.rb
+++ b/lib/i18n/backend/chain.rb
@@ -92,9 +92,13 @@ module I18n
           end
 
           def translations
-            backends.first.instance_eval do
-              init_translations unless initialized?
-              translations
+            backends.reverse.inject({}) do |h, b|
+              to_merge = b.instance_eval do
+                init_translations unless initialized?
+                translations
+              end
+
+              h.deep_merge(to_merge)
             end
           end
 

--- a/test/backend/chain_test.rb
+++ b/test/backend/chain_test.rb
@@ -101,16 +101,19 @@ class I18nBackendChainTest < I18n::TestCase
     assert !@second.initialized?
   end
 
-  test 'should be able to get all translations of the first backend' do
+  test 'should be able to get all translations of all backends merged together' do
     assert_equal I18n.backend.send(:translations),
                  en: {
                    foo: 'Foo',
+                   bar: 'Bar',
                    formats: {
                      short: 'short',
-                     subformats: { short: 'short' }
+                     long: 'long',
+                     subformats: { short: 'short', long: 'long' }
                    },
                    plural_1: { one: "%{count}" },
-                   dates: { a: 'A' }
+                   plural_2: { one: 'one' },
+                   dates: { a: 'A', b: 'B' }
                  }
   end
 


### PR DESCRIPTION
https://github.com/fnando/i18n-js uses the `#translations` method to dump all translations to a javascript file during asset compilation.  The chain backend should deep_merge all these translations in order to dump the appropriate values.

My use case:
I've created a backend which pulls translations from my CMS, and hooked that up in a chain backend to first try the CMS and second try the default .yml files.  I18n-js was not dumping any of the translations from my yml files to the resulting javascript.