### PR TITLE
Fix regression for handling zero integer keys

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -371,7 +371,7 @@ module I18n
           keys.delete('')
           keys.map! do |k|
             case k
-            when /\A[-+]?[1-9]\d*\z/ # integer
+            when /\A(?:0|[-+]?[1-9]\d*)\z/ # integer
               k.to_i
             when 'true'
               true

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -19,9 +19,13 @@ class I18nBackendSimpleTest < I18n::TestCase
   end
 
   test "simple backend translate: given integer as a key" do
-    store_translations :en, available: { 1 => "Yes", 2 => "No" }
+    store_translations :en, available: { 0 => "Dunno", 1 => "Yes", 2 => "No" }
+    assert_equal "Dunno", I18n.t(:available)[0]
+    assert_equal "Dunno", I18n.t('available.0')
     assert_equal "Yes", I18n.t(:available)[1]
     assert_equal "Yes", I18n.t('available.1')
+    assert_equal "No", I18n.t(:available)[2]
+    assert_equal "No", I18n.t('available.2')
   end
 
   test 'simple backend translate: given integer with a lead zero as a key' do


### PR DESCRIPTION
In #457 handling of integer keys with a value equal to just zero (`0`) has been broken. They should be treated consistently with other integer-like keys, like `1`, `2` or `-42`.

Fixed this by enhancing regex to either matching just zero or integer starting not with zero (not to break #456 again).