### PR TITLE
Raise disabled during boot inside fallback

### DIFF
--- a/lib/i18n/locale/fallbacks.rb
+++ b/lib/i18n/locale/fallbacks.rb
@@ -66,6 +66,7 @@ module I18n
 
       def [](locale)
         raise InvalidLocale.new(locale) if locale.nil?
+        raise Disabled.new('fallback#[]') if locale == false
         locale = locale.to_sym
         super || store(locale, compute(locale))
       end

--- a/test/locale/fallbacks_test.rb
+++ b/test/locale/fallbacks_test.rb
@@ -130,4 +130,12 @@ class I18nFallbacksComputationTest < I18n::TestCase
     @fallbacks.map(:no => :nb, :nb => :no)
     assert_equal [:nb, :no, :"en-US", :en], @fallbacks[:nb]
   end
+
+  # Test I18n::Disabled  is raised correctly when locale is false during fallback
+
+  test "with locale equals false" do
+    assert_raise I18n::Disabled do
+      @fallbacks[false]
+    end
+  end
 end


### PR DESCRIPTION
Noticed this code path being hit with `locale == false` in our application after disabling any i18n calls during boot phase. It makes sense to raise Disabled here as well and let the user know about their mistake. 