### PR TITLE
Handle batch key translations in backend(s)

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -184,11 +184,7 @@ module I18n
       backend = config.backend
 
       result = catch(:exception) do
-        if key.is_a?(Array)
-          key.map { |k| backend.translate(locale, k, options) }
-        else
-          backend.translate(locale, key, options)
-        end
+        backend.translate(locale, key, options)
       end
 
       if result.is_a?(MissingTranslation)

--- a/lib/i18n/backend/cascade.rb
+++ b/lib/i18n/backend/cascade.rb
@@ -36,6 +36,11 @@ module I18n
       def lookup(locale, key, scope = [], options = EMPTY_HASH)
         return super unless cascade = options[:cascade]
 
+        # Cascading implementation doesn't play nice with arrays of keys
+        if key.is_a?(Array)
+          return key.map { |k| lookup(locale, k, scope, options) }
+        end
+
         cascade   = { :step => 1 } unless cascade.is_a?(Hash)
         step      = cascade[:step]   || 1
         offset    = cascade[:offset] || 1

--- a/lib/i18n/backend/flatten.rb
+++ b/lib/i18n/backend/flatten.rb
@@ -18,6 +18,10 @@ module I18n
       # and creates way less objects than the one at I18n.normalize_keys.
       # It also handles escaping the translation keys.
       def self.normalize_flat_keys(locale, key, scope, separator)
+        if key.is_a?(Array)
+          return key.map { |k| normalize_flat_keys(locale, k, scope, separator) }
+        end
+
         keys = [scope, key].flatten.compact
         separator ||= I18n.default_separator
 
@@ -88,6 +92,10 @@ module I18n
         end
 
         def resolve_link(locale, key)
+          if key.is_a?(Array)
+            return key.map { |k| resolve_link(locale, k) }
+          end
+
           key, locale = key.to_s, locale.to_sym
           links = self.links[locale]
 

--- a/lib/i18n/backend/key_value.rb
+++ b/lib/i18n/backend/key_value.rb
@@ -136,6 +136,10 @@ module I18n
         end
 
         def lookup(locale, key, scope = [], options = EMPTY_HASH)
+          if key.is_a?(Array)
+            return key.map { |k| lookup(locale, k, scope, options) }
+          end
+
           key   = normalize_flat_keys(locale, key, scope, options[:separator])
           value = @store["#{locale}.#{key}"]
           value = JSON.decode(value) if value

--- a/lib/i18n/backend/memoize.rb
+++ b/lib/i18n/backend/memoize.rb
@@ -35,6 +35,10 @@ module I18n
       protected
 
         def lookup(locale, key, scope = nil, options = EMPTY_HASH)
+          if key.is_a?(Array)
+            return key.map { |k| lookup(locale, k, scope, options) }
+          end
+
           flat_key  = I18n::Backend::Flatten.normalize_flat_keys(locale,
             key, scope, options[:separator]).to_sym
           flat_hash = memoized_lookup[locale.to_sym]

--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -89,6 +89,10 @@ module I18n
         # into multiple keys, i.e. <tt>currency.format</tt> is regarded the same as
         # <tt>%w(currency format)</tt>.
         def lookup(locale, key, scope = [], options = EMPTY_HASH)
+          if key.is_a?(Array)
+            return key.map { |k| lookup(locale, k, scope, options) }
+          end
+
           init_translations unless initialized?
           keys = I18n.normalize_keys(locale, key, scope, options[:separator])
 

--- a/test/backend/memoize_test.rb
+++ b/test/backend/memoize_test.rb
@@ -65,20 +65,23 @@ class I18nBackendMemoizeTest < I18nBackendSimpleTest
       include I18n::Backend::Memoize
     end
     backend = backend_impl.new
-
     memoized_lookup = backend.send(:memoized_lookup)
 
-    assert_equal "[:foo, :scoped, :sample]", backend.translate('foo', scope = [:scoped, :sample])
+    locale = :en
+    scope = [:scoped, :sample]
+
+    assert_equal "[:en, :scoped, :sample, :foo]", backend.translate(locale, 'foo', scope: scope)
 
     30.times.inject([]) do |memo, i|
       memo << Thread.new do
-        backend.translate('bar', scope); backend.translate(:baz, scope)
+        backend.translate(locale, 'bar', scope: scope)
+        backend.translate(locale, :baz, scope: scope)
       end
     end.each(&:join)
 
     memoized_lookup = backend.send(:memoized_lookup)
-    puts memoized_lookup.inspect if $VERBOSE
-    assert_equal 3, memoized_lookup.size, "NON-THREAD-SAFE lookup memoization backend: #{memoized_lookup.class}"
+    assert_equal 1, memoized_lookup.size, "NON-THREAD-SAFE lookup memoization backend: #{memoized_lookup.class}"
+    assert_equal 3, memoized_lookup[:en].size, "NON-THREAD-SAFE lookup memoization backend: #{memoized_lookup[:en].class}"
     # if a plain Hash is used might eventually end up in a weird (inconsistent) state
   end
 

--- a/test/backend/metadata_test.rb
+++ b/test/backend/metadata_test.rb
@@ -45,4 +45,3 @@ class I18nBackendMetadataTest < I18n::TestCase
     assert_equal(1, I18n.t(:missing, :count => 1, :default => 'foo'.freeze).translation_metadata[:count])
   end
 end
-


### PR DESCRIPTION
I18n.translate used to accept an array of keys to translate with a single batch request, but it would immediately execute the code
```ruby
if key.is_a?(Array)
  key.map { |k| backend.translate(locale, k, options) }
else
  backend.translate(locale, key, options)
end
```

Unfortunately, this means that even if your backend is somehow more performant on arrays, your backend doesn't ever receive an array of keys.

Now, instead of the I18n translate interface immediately assuming that a backend will perfrom `translate` serially (one key at a time) I18n just passes the whole list to the backend.

This PR also updates all of the backends (except for cascading backend which seemed particularly complicated to get to play nice with this approach) to support lists of keys.

Obviously this is a backwards-incompatible change. I wonder what you think?