### PR TITLE
Exclude :count option on retrieve link

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -143,7 +143,7 @@ module I18n
           result = catch(:exception) do
             case subject
             when Symbol
-              I18n.translate(subject, **options.merge(:locale => locale, :throw => true))
+              I18n.translate(subject, **options.merge(:locale => locale, :throw => true).except(:count))
             when Proc
               date_or_time = options.delete(:object) || object
               resolve(locale, object, subject.call(date_or_time, options))

--- a/lib/i18n/tests/link.rb
+++ b/lib/i18n/tests/link.rb
@@ -26,7 +26,7 @@ module I18n
         }
         assert_equal('linked', I18n.backend.translate('en', :'foo.link'))
       end
-      
+
       test "linked lookup: if a dot-separated key resolves to a dot-separated symbol it looks up the symbol" do
         I18n.backend.store_translations 'en', {
           :foo => { :link   => :"bar.linked" },
@@ -50,6 +50,16 @@ module I18n
         }
         assert_equal "can't be blank", I18n.t(:"activerecord.errors.messages.blank")
         assert_equal "can't be blank", I18n.t(:"activerecord.errors.messages.blank")
+      end
+
+      test "linked lookup: a link can resolve with option :count" do
+        I18n.backend.store_translations 'en', {
+          :counter => :counted,
+          :counted => { :foo => { :one => "one", :other => "other" }, :bar => "bar" }
+        }
+        assert_equal "one", I18n.t(:'counter.foo', count: 1)
+        assert_equal "other", I18n.t(:'counter.foo', count: 2)
+        assert_equal "bar", I18n.t(:'counter.bar', count: 3)
       end
     end
   end


### PR DESCRIPTION
Using both `count:` option and linked lookup in locale data causes unexpected `I18n::InvalidPluralizationData`.

Locale YAML:
```yaml
en:
  link: :linked
  linked:
    foo:
      one: 1 foo
      other: %{count} foos
```

Code:
```ruby
I18n.t(:'link.foo', count: 2)
```

Expected result:
```
"2 foos"
```

Actual result:
```
translation data {:foo=>{:one=>"1 foo", :other=>"%{count} foos"}} can not be used with :count => 2. key 'one' is missing. (I18n::InvalidPluralizationData)
```