### PR TITLE
remove public :include

### DIFF
--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -21,8 +21,6 @@ module I18n
     class Simple
       using I18n::HashRefinements
 
-      (class << self; self; end).class_eval { public :include }
-
       module Implementation
         include Base
 


### PR DESCRIPTION
#include is public since ruby 2.1, i18n requres 2.3+, so this patch is no longer necessary