### PR TITLE
Add an option to disable fallbacks for the I18n.exists? check 

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -207,11 +207,11 @@ module I18n
     alias :t! :translate!
 
     # Returns true if a translation exists for a given key, otherwise returns false.
-    def exists?(key, _locale = nil, locale: _locale)
+    def exists?(key, _locale = nil, locale: _locale, **options)
       locale ||= config.locale
       raise Disabled.new('exists?') if locale == false
       raise I18n::ArgumentError if key.is_a?(String) && key.empty?
-      config.backend.exists?(locale, key)
+      config.backend.exists?(locale, key, options)
     end
 
     # Transliterates UTF-8 characters to ASCII. By default this method will

--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -64,7 +64,7 @@ module I18n
         entry
       end
 
-      def exists?(locale, key)
+      def exists?(locale, key, options = EMPTY_HASH)
         lookup(locale, key) != nil
       end
 

--- a/lib/i18n/backend/chain.rb
+++ b/lib/i18n/backend/chain.rb
@@ -73,9 +73,9 @@ module I18n
           throw(:exception, I18n::MissingTranslation.new(locale, key, options))
         end
 
-        def exists?(locale, key)
+        def exists?(locale, key, options = EMPTY_HASH)
           backends.any? do |backend|
-            backend.exists?(locale, key)
+            backend.exists?(locale, key, options)
           end
         end
 

--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -68,7 +68,8 @@ module I18n
         return first_non_symbol_default
       end
 
-      def exists?(locale, key)
+      def exists?(locale, key, options = EMPTY_HASH)
+        return super unless options.fetch(:fallback, true)
         I18n.fallbacks[locale].each do |fallback|
           begin
             return true if super(fallback, key)

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -154,6 +154,14 @@ class I18nBackendFallbacksWithChainTest < I18n::TestCase
     assert_equal 'FOO', I18n.t(:foo, :locale => :'de-DE')
   end
 
+  test "exists? falls back from de-DE to de given a key missing from the given locale" do
+    assert_equal true, I18n.exists?(:foo, :locale => :'de-DE')
+  end
+
+  test "exists? should return false when fallback disabled given a key missing from the given locale" do
+    assert_equal false, I18n.exists?(:foo, :locale => :'de-DE', fallback: false)
+  end
+
   test "falls back from de-DE to de when there is no translation for de-DE available when using arrays, too" do
     assert_equal ['FOO', 'FOO'], I18n.t([:foo, :foo], :locale => :'de-DE')
   end
@@ -207,5 +215,11 @@ class I18nBackendFallbacksExistsTest < I18n::TestCase
   test "exists? should return false given a key which is missing from the given locale and all its fallback locales" do
     assert_equal false, I18n.exists?(:baz, :de)
     assert_equal false, I18n.exists?(:bogus, :'de-DE')
+  end
+
+  test "exists? should return false when fallback is disabled given a key which is missing from the given locale" do
+    assert_equal true, I18n.exists?(:bar, :'de-DE')
+    assert_equal false, I18n.exists?(:bar, :'de-DE', fallback: false)
+    assert_equal false, I18n.exists?(:bar, :'de-DE-XX', fallback: false)
   end
 end


### PR DESCRIPTION
Issue: https://github.com/ruby-i18n/i18n/issues/365

This PR adds a option to disable fallbacks for the `I18n.exists?` method in the Fallbacks backend.

Before, with fallbacks enabled, the following would return true because the `exists?` check would fallback from `fr-CA` to `fr`.
```
I18n.exists?('key_only_found_in_fr', locale: :'fr-CA') # returns true
```


Now, similar to how `I18n.t` has the option to disable fallbacks, we can do the following if we don't want to fallback: 
```
I18n.exists?('key_only_found_in_fr', locale: :'fr-CA', fallback: false) # returns false
``` 

### Screenshots: 
<img width="800" alt="Screen Shot 2019-06-24 at 6 50 16 PM" src="https://user-images.githubusercontent.com/26511081/60057861-17422000-96b4-11e9-8974-75200764385c.png">

Let me know what you guys think :) 