### PR TITLE
Removed rubyforge_project from gemspec. 

### DIFF
--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob("lib/**/*") + %w(README.md MIT-LICENSE)
   s.platform     = Gem::Platform::RUBY
   s.require_path = 'lib'
-  s.rubyforge_project = '[none]'
   s.required_rubygems_version = '>= 1.3.5'
   s.required_ruby_version = '>= 2.3.0'
 


### PR DESCRIPTION
Because rubyforge was EOL.