### PR TITLE
Keyword arguments have to be explicitly double-splatted in Ruby 2.7+

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -202,7 +202,7 @@ module I18n
     # Wrapper for <tt>translate</tt> that adds <tt>:raise => true</tt>. With
     # this option, if no translation is found, it will raise <tt>I18n::MissingTranslationData</tt>
     def translate!(key, options = EMPTY_HASH)
-      translate(key, options.merge(:raise => true))
+      translate(key, **options.merge(:raise => true))
     end
     alias :t! :translate!
 

--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -81,7 +81,7 @@ module I18n
           key  = format
           type = object.respond_to?(:sec) ? 'time' : 'date'
           options = options.merge(:raise => true, :object => object, :locale => locale)
-          format  = I18n.t(:"#{type}.formats.#{key}", options)
+          format  = I18n.t(:"#{type}.formats.#{key}", **options)
         end
 
         format = translate_localization_format(locale, object, format, options)
@@ -143,7 +143,7 @@ module I18n
           result = catch(:exception) do
             case subject
             when Symbol
-              I18n.translate(subject, options.merge(:locale => locale, :throw => true))
+              I18n.translate(subject, **options.merge(:locale => locale, :throw => true))
             when Proc
               date_or_time = options.delete(:object) || object
               resolve(locale, object, subject.call(date_or_time, options))

--- a/lib/i18n/gettext/helpers.rb
+++ b/lib/i18n/gettext/helpers.rb
@@ -19,7 +19,7 @@ module I18n
       end
 
       def gettext(msgid, options = EMPTY_HASH)
-        I18n.t(msgid, { :default => msgid, :separator => '|' }.merge(options))
+        I18n.t(msgid, **{:default => msgid, :separator => '|'}.merge(options))
       end
       alias _ gettext
 

--- a/lib/i18n/tests/localization/date.rb
+++ b/lib/i18n/tests/localization/date.rb
@@ -68,9 +68,9 @@ module I18n
 
         test "localize Date: does not modify the options hash" do
           options = { :format => '%b', :locale => :de }
-          assert_equal 'Mär', I18n.l(@date, options)
+          assert_equal 'Mär', I18n.l(@date, **options)
           assert_equal({ :format => '%b', :locale => :de }, options)
-          assert_nothing_raised { I18n.l(@date, options.freeze) }
+          assert_nothing_raised { I18n.l(@date, **options.freeze) }
         end
 
         test "localize Date: given nil with default value it returns default" do

--- a/lib/i18n/tests/localization/procs.rb
+++ b/lib/i18n/tests/localization/procs.rb
@@ -59,7 +59,7 @@ module I18n
           setup_time_proc_translations
           time = ::Time.utc(2008, 3, 1, 6, 0)
           options = { :foo => 'foo' }
-          assert_equal I18n::Tests::Localization::Procs.inspect_args([time, options]), I18n.l(time, options.merge(:format => :proc, :locale => :ru))
+          assert_equal I18n::Tests::Localization::Procs.inspect_args([time, options]), I18n.l(time, **options.merge(:format => :proc, :locale => :ru))
         end
 
         protected

--- a/lib/i18n/tests/lookup.rb
+++ b/lib/i18n/tests/lookup.rb
@@ -43,9 +43,9 @@ module I18n
 
       test "lookup: does not modify the options hash" do
         options = {}
-        assert_equal "a", I18n.t(:string, options)
+        assert_equal "a", I18n.t(:string, **options)
         assert_equal({}, options)
-        assert_nothing_raised { I18n.t(:string, options.freeze) }
+        assert_nothing_raised { I18n.t(:string, **options.freeze) }
       end
 
       test "lookup: given an array of keys it translates all of them" do

--- a/test/api/override_test.rb
+++ b/test/api/override_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class I18nOverrideTest < I18n::TestCase
   module OverrideInverse
-    def translate(*args)
-      super(*args).reverse
+    def translate(*args, **options)
+      super(*args, **options).reverse
     end
     alias :t :translate
   end

--- a/test/backend/cascade_test.rb
+++ b/test/backend/cascade_test.rb
@@ -13,7 +13,7 @@ class I18nBackendCascadeTest < I18n::TestCase
   end
 
   def lookup(key, options = {})
-    I18n.t(key, options.merge(:cascade => @cascade_options))
+    I18n.t(key, **options.merge(:cascade => @cascade_options))
   end
 
   test "still returns an existing translation as usual" do

--- a/test/i18n/exceptions_test.rb
+++ b/test/i18n/exceptions_test.rb
@@ -89,7 +89,7 @@ class I18nExceptionsTest < I18n::TestCase
 
     def force_missing_translation_data(options = {})
       store_translations('de', :bar => nil)
-      I18n.translate(:foo, options.merge(:scope => :bar, :locale => :de))
+      I18n.translate(:foo, **options.merge(:scope => :bar, :locale => :de))
     rescue I18n::ArgumentError => e
       block_given? ? yield(e) : raise(e)
     end


### PR DESCRIPTION
This PR updates the code base to be Ruby 3.0 compatible.

After a very long discussion at https://bugs.ruby-lang.org/issues/14183, the Ruby core team finally decided to introduce a slight incompatibility to keyword arguments from Ruby 3.0, i.e. complete separation between keyword arguments literal and Hash literal.
With that, current Ruby master warns when a Hash object was passed in as keyword arguments

```
$ ruby -ve 'def f(x: nil) p x; end; hash = {x: 1}; f(hash)'
ruby 2.7.0dev (2019-09-02T05:20:05Z master 83498854eb) [x86_64-darwin18]
warning: The last argument is used as the keyword parameter
warning: for `f' defined here
```

To eliminate this warning, we need to prefix a "double splat" (`**`) to avoid ambiguity.

```
$ ruby -ve 'def f(x: nil) p x;end; hash = {x: 1}; f(**hash)'
ruby 2.7.0dev (2019-09-02T05:20:05Z master 83498854eb) [x86_64-darwin18]
1
```

This PR fixes all Ruby 2.7 warnings (this ensures that this code works with Ruby 3.0) without breaking compatibility with Ruby < 2.7.