### PR TITLE
GitHub is https by default

### DIFF
--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version      = I18n::VERSION
   s.authors      = ["Sven Fuchs", "Joshua Harvey", "Matt Aimonetti", "Stephan Soller", "Saimon Moore", "Ryan Bigg"]
   s.email        = "rails-i18n@googlegroups.com"
-  s.homepage     = "http://github.com/ruby-i18n/i18n"
+  s.homepage     = "https://github.com/ruby-i18n/i18n"
   s.summary      = "New wave Internationalization support for Ruby"
   s.description  = "New wave Internationalization support for Ruby."
   s.license      = "MIT"


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/i18n or some tools or APIs that use the gem's metadata.