### PR TITLE
Reduce Hash object allocations

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -122,7 +122,7 @@ module I18n
         # first translation that can be resolved. Otherwise it tries to resolve
         # the translation directly.
         def default(locale, object, subject, options = EMPTY_HASH)
-          options = options.dup.reject { |key, value| key == :default }
+          options = options.reject { |key, value| key == :default }
           case subject
           when Array
             subject.each do |item|


### PR DESCRIPTION
This patch reduces a Hash object allocation from `I18n#default` which is invoked from `I18n#translate`.