### PR TITLE
Make all cases for I18n::Backend::Base#interpolation clearer.

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -180,6 +180,10 @@ module I18n
         #   each element of the array is recursively interpolated (until it finds a string)
         #   method interpolates ["yes, %{user}", ["maybe no, %{user}, "no, %{user}"]], :user => "bartuz"
         #   # => "["yes, bartuz",["maybe no, bartuz", "no, bartuz"]]"
+        #
+        #   if this method is given an unknown value type e.g. (proc):
+        #   the subject should be returned as is.
+        #
         def interpolate(locale, subject, values = EMPTY_HASH)
           return subject if values.empty?
 


### PR DESCRIPTION
While extending I18n::Backend::Base to create a custom backend I defined an override for #interpolation however I was facing a lot of issues when integrating it with our application. After a session of debugging I realized `#interpolation` was being called with a `Proc` in certain scenarios.

Since it is clear the method is defined in a way to support this I though It would be worth updating the documentation to be a bit clearer around this.