### PR TITLE
Chain fallback backends

### DIFF
--- a/lib/i18n/backend/chain.rb
+++ b/lib/i18n/backend/chain.rb
@@ -101,8 +101,7 @@ module I18n
                 init_translations unless initialized?
                 translations
               end
-
-              memo.deep_merge!(partial_translations)
+              memo.deep_merge!(partial_translations) { |_, a, b| b || a }
             end
           end
 

--- a/lib/i18n/core_ext/hash.rb
+++ b/lib/i18n/core_ext/hash.rb
@@ -18,12 +18,18 @@ module I18n
         end
       end
 
-      # deep_merge_hash! by Stefan Rusterholz, see http://www.ruby-forum.com/topic/142809
-      def deep_merge!(data)
-        merger = lambda do |_key, v1, v2|
-          Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2
+      # deep_merge! from activesupport 5
+      # Copyright (c) 2005-2019 David Heinemeier Hansson
+      def deep_merge!(other_hash, &block)
+        merge!(other_hash) do |key, this_val, other_val|
+          if this_val.is_a?(Hash) && other_val.is_a?(Hash)
+            this_val.deep_merge(other_val, &block)
+          elsif block_given?
+            block.call(key, this_val, other_val)
+          else
+            other_val
+          end
         end
-        merge!(data, &merger)
       end
 
       def symbolize_key(key)

--- a/test/backend/chain_test.rb
+++ b/test/backend/chain_test.rb
@@ -9,7 +9,8 @@ class I18nBackendChainTest < I18n::TestCase
         :subformats => {:short => 'short'},
       },
       :plural_1 => { :one => '%{count}' },
-      :dates => {:a => "A"}
+      :dates => {:a => "A"},
+      :fallback_bar => nil,
     })
     @second = backend(:en => {
       :bar => 'Bar', :formats => {
@@ -17,7 +18,8 @@ class I18nBackendChainTest < I18n::TestCase
         :subformats => {:long => 'long'},
       },
       :plural_2 => { :one => 'one' },
-      :dates => {:a => "B", :b => "B"}
+      :dates => {:a => "B", :b => "B"},
+      :fallback_bar => 'Bar',
     })
     @chain  = I18n.backend = I18n::Backend::Chain.new(@first, @second)
   end
@@ -107,20 +109,29 @@ class I18nBackendChainTest < I18n::TestCase
     assert @second.initialized?
   end
 
+  test "falls back to other backends for nil values" do
+    assert_nil @first.send(:translations)[:en][:fallback_bar]
+    assert_equal 'Bar', @second.send(:translations)[:en][:fallback_bar]
+    assert_equal 'Bar', I18n.t(:fallback_bar)
+  end
+
   test 'should be able to get all translations of all backends merged together' do
-    assert_equal I18n.backend.send(:translations),
-                 en: {
-                   foo: 'Foo',
-                   bar: 'Bar',
-                   formats: {
-                     short: 'short',
-                     long: 'long',
-                     subformats: { short: 'short', long: 'long' }
-                   },
-                   plural_1: { one: "%{count}" },
-                   plural_2: { one: 'one' },
-                   dates: { a: 'A', b: 'B' }
-                 }
+    expected = {
+      en: {
+        foo: 'Foo',
+        bar: 'Bar',
+        formats: {
+          short: 'short',
+          long: 'long',
+          subformats: { short: 'short', long: 'long' }
+        },
+        plural_1: { one: "%{count}" },
+        plural_2: { one: 'one' },
+        dates: { a: 'A', b: 'B' },
+        fallback_bar: 'Bar'
+      }
+    }
+    assert_equal expected, I18n.backend.send(:translations)
   end
 
   protected


### PR DESCRIPTION
Building on #470, if using fnando/i18n-js and some translations are present in a Simple backend, and some in an ActiveRecord backend, the current `deep_merge!` done in the chain backend will override a valid translation with a nil value if a previously chained backend yields nil.

This patch updates the `Hash#deep_merge!` implementation to match the activesupport one, and provides a block to prevent nil values from affecting translations yielded by a chained backend.

Use case:
I'm using a chain backend of (Simple, ActiveRecord). The simple backend has an empty or partial YAML, like this:

```yaml
---
en:
  test:
```

The activerecord backend has a record that overrides it:
```
> select * from translations where locale = 'en' and key = 'test';

| locale | key  | value | ...
+--------+------+-------+----
|     en | test |  Test | ...
```
I think the nil YAML value shouldn't prevent the other backend from yielding its value, that's how `I18n::Backend::Chain#translate` works, after all.

Thanks for reviewing this!