### PR TITLE
Replace TravisCI badge with GH Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ruby I18n
 
-[![Build Status](https://api.travis-ci.org/ruby-i18n/i18n.svg?branch=master)](https://travis-ci.org/ruby-i18n/i18n)
+[![Build Status](https://github.com/ruby-i18n/i18n/workflows/Ruby/badge.svg)](https://github.com/ruby-i18n/i18n/actions?query=workflow%3ARuby)
 
 Ruby Internationalization and localization solution.
 


### PR DESCRIPTION
Since this repo is not using TravisCI anymore, the current build badge is not
reflecting the correct build status.

This commit updates the README with the workflow badge from GH Actions.