### PR TITLE
Fix missing deep_merge without reverting chain fallback backends

### DIFF
--- a/lib/i18n/backend/chain.rb
+++ b/lib/i18n/backend/chain.rb
@@ -101,8 +101,7 @@ module I18n
                 init_translations unless initialized?
                 translations
               end
-
-              memo.deep_merge!(partial_translations)
+              memo.deep_merge!(partial_translations) { |_, a, b| b || a }
             end
           end
 

--- a/lib/i18n/core_ext/hash.rb
+++ b/lib/i18n/core_ext/hash.rb
@@ -18,6 +18,12 @@ module I18n
         end
       end
 
+      # deep_merge from activesupport 5
+      # Copyright (c) 2005-2019 David Heinemeier Hansson
+      def deep_merge(other_hash, &block)
+        dup.deep_merge!(other_hash, &block)
+      end
+
       # deep_merge_hash! by Stefan Rusterholz, see http://www.ruby-forum.com/topic/142809
       def deep_merge!(data)
         merger = lambda do |_key, v1, v2|

--- a/lib/i18n/core_ext/hash.rb
+++ b/lib/i18n/core_ext/hash.rb
@@ -24,12 +24,18 @@ module I18n
         dup.deep_merge!(other_hash, &block)
       end
 
-      # deep_merge_hash! by Stefan Rusterholz, see http://www.ruby-forum.com/topic/142809
-      def deep_merge!(data)
-        merger = lambda do |_key, v1, v2|
-          Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2
+      # deep_merge! from activesupport 5
+      # Copyright (c) 2005-2019 David Heinemeier Hansson
+      def deep_merge!(other_hash, &block)
+        merge!(other_hash) do |key, this_val, other_val|
+          if this_val.is_a?(Hash) && other_val.is_a?(Hash)
+            this_val.deep_merge(other_val, &block)
+          elsif block_given?
+            block.call(key, this_val, other_val)
+          else
+            other_val
+          end
         end
-        merge!(data, &merger)
       end
 
       def symbolize_key(key)

--- a/test/backend/chain_test.rb
+++ b/test/backend/chain_test.rb
@@ -9,7 +9,8 @@ class I18nBackendChainTest < I18n::TestCase
         :subformats => {:short => 'short'},
       },
       :plural_1 => { :one => '%{count}' },
-      :dates => {:a => "A"}
+      :dates => {:a => "A"},
+      :fallback_bar => nil,
     })
     @second = backend(:en => {
       :bar => 'Bar', :formats => {
@@ -17,7 +18,8 @@ class I18nBackendChainTest < I18n::TestCase
         :subformats => {:long => 'long'},
       },
       :plural_2 => { :one => 'one' },
-      :dates => {:a => "B", :b => "B"}
+      :dates => {:a => "B", :b => "B"},
+      :fallback_bar => 'Bar',
     })
     @chain  = I18n.backend = I18n::Backend::Chain.new(@first, @second)
   end
@@ -107,20 +109,29 @@ class I18nBackendChainTest < I18n::TestCase
     assert @second.initialized?
   end
 
+  test "falls back to other backends for nil values" do
+    assert_nil @first.send(:translations)[:en][:fallback_bar]
+    assert_equal 'Bar', @second.send(:translations)[:en][:fallback_bar]
+    assert_equal 'Bar', I18n.t(:fallback_bar)
+  end
+
   test 'should be able to get all translations of all backends merged together' do
-    assert_equal I18n.backend.send(:translations),
-                 en: {
-                   foo: 'Foo',
-                   bar: 'Bar',
-                   formats: {
-                     short: 'short',
-                     long: 'long',
-                     subformats: { short: 'short', long: 'long' }
-                   },
-                   plural_1: { one: "%{count}" },
-                   plural_2: { one: 'one' },
-                   dates: { a: 'A', b: 'B' }
-                 }
+    expected = {
+      en: {
+        foo: 'Foo',
+        bar: 'Bar',
+        formats: {
+          short: 'short',
+          long: 'long',
+          subformats: { short: 'short', long: 'long' }
+        },
+        plural_1: { one: "%{count}" },
+        plural_2: { one: 'one' },
+        dates: { a: 'A', b: 'B' },
+        fallback_bar: 'Bar'
+      }
+    }
+    assert_equal expected, I18n.backend.send(:translations)
   end
 
   protected


### PR DESCRIPTION
Adds `Hash#deep_merge` to fix #507 while re-introducing the functionality of #499