### PR TITLE
Fix pluralize on unknown locale with attributes

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -163,6 +163,7 @@ module I18n
         #   not standard with regards to the CLDR pluralization rules.
         # Other backends can implement more flexible or complex pluralization rules.
         def pluralize(locale, entry, count)
+          entry = entry.reject { |k, _v| k == :attributes } if entry.is_a?(Hash)
           return entry unless entry.is_a?(Hash) && count && entry.values.none? { |v| v.is_a?(Hash) }
 
           key = pluralization_key(entry, count)

--- a/test/backend/pluralization_test.rb
+++ b/test/backend/pluralization_test.rb
@@ -39,6 +39,11 @@ class I18nBackendPluralizationTest < I18n::TestCase
     assert_equal 'few', I18n.t(:count => 0, :default => @entry, :locale => :xx)
   end
 
+  test "pluralization picks one for 1 if the entry has attributes hash on unknown locale" do
+    @entry[:attributes] = { :field => 'field', :second => 'second' }
+    assert_equal 'one', I18n.t(:count => 1, :default => @entry, :locale => :pirate)
+  end
+
   test "Fallbacks can pick up rules from fallback locales, too" do
     assert_equal @rule, I18n.backend.send(:pluralizer, :'xx-XX')
   end


### PR DESCRIPTION
When i use a unknown locale(without a rule for plural) on activerecord.models key(in a rails project) and with the attributes key inside too, i have a issue, because the pluralize return the full hash, and not the "one" or "other" pluralize. 