### PR TITLE
Fix Ruby 2.7 keyword arguments related deprecation warning in Proc call

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -146,7 +146,7 @@ module I18n
               I18n.translate(subject, **options.merge(:locale => locale, :throw => true))
             when Proc
               date_or_time = options.delete(:object) || object
-              resolve(locale, object, subject.call(date_or_time, options))
+              resolve(locale, object, subject.call(date_or_time, **options))
             else
               subject
             end


### PR DESCRIPTION
In translation files like https://github.com/rails/rails/blob/v6.0.2.1/activesupport/lib/active_support/locale/en.rb, a method is being specified that receives keyword arguments. However, the `Proc.call` in `backend/base.rb#resolve` passes a hash. This causes a Ruby deprecation warning.

This PR adds the double-splat operator to resolve this issue.