### PR TITLE
Revert "Fix Ruby 2.7 keyword arguments related deprecation warning in Proc call"

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -146,7 +146,7 @@ module I18n
               I18n.translate(subject, **options.merge(:locale => locale, :throw => true))
             when Proc
               date_or_time = options.delete(:object) || object
-              resolve(locale, object, subject.call(date_or_time, **options))
+              resolve(locale, object, subject.call(date_or_time, options))
             else
               subject
             end


### PR DESCRIPTION
Reverts ruby-i18n/i18n#521

This broke the built on 2.7.0.

https://github.com/ruby-i18n/i18n/actions/runs/66085087

