### PR TITLE
Fixing the CI failure by double-splatting the arguments for I18n.translate

### DIFF
--- a/test/backend/pluralization_scope_test.rb
+++ b/test/backend/pluralization_scope_test.rb
@@ -40,7 +40,7 @@ class I18nBackendPluralizationScopeTest < I18n::TestCase
       count: 2,
       default: ["My model"]
     }
-    assert_equal 'more models', I18n.translate(:my_model, args)
+    assert_equal 'more models', I18n.translate(:my_model, **args)
   end
 
   test "pluralization picks :one for 1" do
@@ -49,7 +49,7 @@ class I18nBackendPluralizationScopeTest < I18n::TestCase
       count: 1,
       default: ["My model"]
     }
-    assert_equal 'one model', I18n.translate(:my_model, args)
+    assert_equal 'one model', I18n.translate(:my_model, **args)
   end
 
 end


### PR DESCRIPTION
Here's a tiny patch on the test code that may fix the CI breakage.