### PR TITLE
Bunch of speed and memory optimizations

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -389,7 +389,7 @@ module I18n
       @@normalized_key_cache[separator][key] ||=
         case key
         when Array
-          key.map { |k| normalize_key(k, separator) }.flatten
+          key.flat_map { |k| normalize_key(k, separator) }
         else
           keys = key.to_s.split(separator)
           keys.delete('')

--- a/lib/i18n/locale/fallbacks.rb
+++ b/lib/i18n/locale/fallbacks.rb
@@ -60,7 +60,7 @@ module I18n
       end
 
       def defaults=(defaults)
-        @defaults = defaults.map { |default| compute(default, false) }.flatten
+        @defaults = defaults.flat_map { |default| compute(default, false) }
       end
       attr_reader :defaults
 

--- a/lib/i18n/locale/fallbacks.rb
+++ b/lib/i18n/locale/fallbacks.rb
@@ -84,13 +84,15 @@ module I18n
       protected
 
       def compute(tags, include_defaults = true, exclude = [])
-        result = Array(tags).collect do |tag|
+        result = Array(tags).flat_map do |tag|
           tags = I18n::Locale::Tag.tag(tag).self_and_parents.map! { |t| t.to_sym } - exclude
           tags.each { |_tag| tags += compute(@map[_tag], false, exclude + tags) if @map[_tag] }
           tags
-        end.flatten
+        end
         result.push(*defaults) if include_defaults
-        result.uniq.compact
+        result.uniq!
+        result.compact!
+        result
       end
     end
   end

--- a/lib/i18n/locale/tag/parents.rb
+++ b/lib/i18n/locale/tag/parents.rb
@@ -3,18 +3,20 @@ module I18n
     module Tag
       module Parents
         def parent
-          @parent ||= begin
-            segs = to_a.compact
-            segs.length > 1 ? self.class.tag(*segs[0..(segs.length-2)].join('-')) : nil
-          end
+          @parent ||=
+            begin
+              segs = to_a
+              segs.compact!
+              segs.length > 1 ? self.class.tag(*segs[0..(segs.length - 2)].join('-')) : nil
+            end
         end
 
         def self_and_parents
-          @self_and_parents ||= [self] + parents
+          @self_and_parents ||= [self].concat parents
         end
 
         def parents
-          @parents ||= ([parent] + (parent ? parent.parents : [])).compact
+          @parents ||= parent ? [parent].concat(parent.parents) : []
         end
       end
     end

--- a/lib/i18n/locale/tag/simple.rb
+++ b/lib/i18n/locale/tag/simple.rb
@@ -19,7 +19,7 @@ module I18n
         end
 
         def subtags
-          @subtags = tag.to_s.split('-').map { |subtag| subtag.to_s }
+          @subtags = tag.to_s.split('-').map!(&:to_s)
         end
 
         def to_sym


### PR DESCRIPTION
`I18n::Locale::Fallbacks.new[locale]` is faster around 30% and uses around 40% less memory

```ruby
I18n::Locale::Fallbacks.new[:de]

Before:
Calculating -------------------------------------
            original     1.696k memsize (     0.000  retained)
                        36.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)

Warming up --------------------------------------
            original     9.584k i/100ms
Calculating -------------------------------------
            original    100.989k (± 2.9%) i/s -    507.952k in   5.034224s


After:
Calculating -------------------------------------
            original     1.056k memsize (     0.000  retained)
                        20.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)

Warming up --------------------------------------
            original    13.143k i/100ms
Calculating -------------------------------------
            original    135.522k (± 3.4%) i/s -    683.436k in   5.049384s
```

```ruby
I18n::Locale::Fallbacks.new[:'en-US']

Before:
Calculating -------------------------------------
            original     2.496k memsize (     0.000  retained)
                        55.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)

ips benchmark:
Warming up --------------------------------------
            original     6.597k i/100ms
Calculating -------------------------------------
            original     68.147k (± 4.8%) i/s -    343.044k in   5.046789s


After:
Calculating -------------------------------------
            original     1.696k memsize (     0.000  retained)
                        35.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)

ips benchmark:
Warming up --------------------------------------
            original     8.169k i/100ms
Calculating -------------------------------------
            original     87.410k (± 2.7%) i/s -    441.126k in   5.050400s
```