### PR TITLE
Pass options as keyword arguments to translation procs

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -146,7 +146,7 @@ module I18n
               I18n.translate(subject, **options.merge(:locale => locale, :throw => true))
             when Proc
               date_or_time = options.delete(:object) || object
-              resolve(locale, object, subject.call(date_or_time, options))
+              resolve(locale, object, subject.call(date_or_time, **options))
             else
               subject
             end

--- a/lib/i18n/tests/localization/procs.rb
+++ b/lib/i18n/tests/localization/procs.rb
@@ -52,19 +52,20 @@ module I18n
         test "localize Time: given a format that resolves to a Proc it calls the Proc with the object" do
           setup_time_proc_translations
           time = ::Time.utc(2008, 3, 1, 6, 0)
-          assert_equal I18n::Tests::Localization::Procs.inspect_args([time, {}]), I18n.l(time, :format => :proc, :locale => :ru)
+          assert_equal I18n::Tests::Localization::Procs.inspect_args([time], {}), I18n.l(time, :format => :proc, :locale => :ru)
         end
 
         test "localize Time: given a format that resolves to a Proc it calls the Proc with the object and extra options" do
           setup_time_proc_translations
           time = ::Time.utc(2008, 3, 1, 6, 0)
           options = { :foo => 'foo' }
-          assert_equal I18n::Tests::Localization::Procs.inspect_args([time, options]), I18n.l(time, **options.merge(:format => :proc, :locale => :ru))
+          assert_equal I18n::Tests::Localization::Procs.inspect_args([time], options), I18n.l(time, **options.merge(:format => :proc, :locale => :ru))
         end
 
         protected
 
-          def self.inspect_args(args)
+          def self.inspect_args(args, kwargs)
+            args << kwargs
             args = args.map do |arg|
               case arg
               when ::Time, ::DateTime
@@ -85,12 +86,12 @@ module I18n
             I18n.backend.store_translations :ru, {
               :time => {
                 :formats => {
-                  :proc => lambda { |*args| I18n::Tests::Localization::Procs.inspect_args(args) }
+                  :proc => lambda { |*args, **kwargs| I18n::Tests::Localization::Procs.inspect_args(args, kwargs) }
                 }
               },
               :date => {
                 :formats => {
-                  :proc => lambda { |*args| I18n::Tests::Localization::Procs.inspect_args(args) }
+                  :proc => lambda { |*args, **kwargs| I18n::Tests::Localization::Procs.inspect_args(args, kwargs) }
                 },
                 :'day_names' => lambda { |key, options|
                   (options[:format] =~ /^%A/) ?

--- a/lib/i18n/tests/procs.rb
+++ b/lib/i18n/tests/procs.rb
@@ -8,6 +8,11 @@ module I18n
         assert_equal '[:a_lambda, {:foo=>"foo"}]', I18n.t(:a_lambda, :foo => 'foo')
       end
 
+      test "lookup: given a translation is a proc it passes the interpolation values as keyword arguments" do
+        I18n.backend.store_translations(:en, :a_lambda => lambda { |key, foo:, **| I18n::Tests::Procs.filter_args(key, foo: foo) })
+        assert_equal '[:a_lambda, {:foo=>"foo"}]', I18n.t(:a_lambda, :foo => 'foo')
+      end
+
       test "defaults: given a default is a Proc it calls it with the key and interpolation values" do
         proc = lambda { |*args| I18n::Tests::Procs.filter_args(*args) }
         assert_equal '[nil, {:foo=>"foo"}]', I18n.t(nil, :default => proc, :foo => 'foo')


### PR DESCRIPTION
So a pattern that's heavily used in our translation data, is to use keyword arguments in translations procs rather than an option hash, e.g:

```ruby
lambda do |_key, number:, **|
  if number == 1
    'er'
  else
    'e'
end
```

Instead of:

```ruby
lambda do |_key, options|
  if options.fetch(:number) == 1
    'er'
  else
    'e'
end
```

It makes for slightly more concise code, and gives better error messages if a key is missing.

However since the signature I18n call is `call(String, Hash)` this causes warnings on 2.7 and will break on 2.8/3.0.

```
gem/ruby/2.7.1/gems/i18n-1.8.2/lib/i18n/backend/base.rb:149: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
config/locales/rules/de.rb:8: warning: The called method `call' is defined here
```

I can off course rewrite these callbacks, but since I believe using keyword args is often nicer, I wanted to check if there was interest in updating the signature.

AFAIK this is backward compatible, as `call(String, **Hash)` will automatically pass the keyword args as a positional hash if the proc doesn't accept keyword args:

```ruby
l = lambda do |_key, options|
  if options.fetch(:number) == 1
    'er'
  else
    'e'
  end
end
hash = { number: 1}
p l.call('foo', **hash) # No warnings
```
