### PR TITLE
Fix deprecate_constant INTERPOLATION_PATTERN

### DIFF
--- a/lib/i18n/interpolate/ruby.rb
+++ b/lib/i18n/interpolate/ruby.rb
@@ -8,7 +8,7 @@ module I18n
     /%<(\w+)>(.*?\d*\.?\d*[bBdiouxXeEfgGcps])/  # matches placeholders like "%<foo>.d"
   ].freeze
   INTERPOLATION_PATTERN = Regexp.union(DEFAULT_INTERPOLATION_PATTERNS)
-  deprecate_constant :INTERPOLATION_PATTERN if method_defined? :INTERPOLATION_PATTERN
+  deprecate_constant :INTERPOLATION_PATTERN if respond_to? :deprecate_constant
 
   class << self
     # Return String or raises MissingInterpolationArgument exception.


### PR DESCRIPTION
`deprecate_constant` `I18n::INTERPOLATION_PATTERN` if `Module` responds to `:deprecate_constant`

Change introduced in #439 looks like it deprecates this constant, but the original condition will always evaluate as false.