### PR TITLE
Always instantiate I18n::Locale::Fallbacks objects when using I18n.fallbacks=

### DIFF
--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -20,7 +20,7 @@ module I18n
 
     # Sets the current fallbacks implementation. Use this to set a different fallbacks implementation.
     def fallbacks=(fallbacks)
-      @@fallbacks = fallbacks
+      @@fallbacks = fallbacks.is_a?(I18n::Locale::Fallbacks) ? fallbacks : I18n::Locale::Fallbacks.new(fallbacks)
     end
   end
 

--- a/lib/i18n/locale/fallbacks.rb
+++ b/lib/i18n/locale/fallbacks.rb
@@ -26,7 +26,7 @@
 #
 #   I18n.default_locale = :"en-US"
 #   I18n.fallbacks = I18n::Locale::Fallbacks.new(:"de-AT" => :"de-DE")
-#   I18n.fallbacks[:"de-AT"] # => [:"de-AT", :"de-DE", :de, :"en-US", :en]
+#   I18n.fallbacks[:"de-AT"] # => [:"de-AT", :de, :"de-DE"]
 #
 #   # using a custom locale as default fallback locale
 #

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -109,6 +109,25 @@ class I18nBackendFallbacksTranslateTest < I18n::TestCase
   end
 end
 
+# See Issue #534
+class I18nBackendFallbacksLocalizeTestWithDefaultLocale < I18n::TestCase
+  class Backend < I18n::Backend::Simple
+    include I18n::Backend::Fallbacks
+  end
+
+  def setup
+    super
+    I18n.backend = Backend.new
+    I18n.enforce_available_locales = false
+    I18n.fallbacks = [I18n.default_locale]
+    store_translations(:en, time: { formats: { fallback: 'en fallback' } })
+  end
+
+  test "falls back to default locale - Issue #534" do
+    assert_equal 'en fallback', I18n.l(Time.now, format: :fallback, locale: "un-supported")
+  end
+end
+
 class I18nBackendFallbacksLocalizeTest < I18n::TestCase
   class Backend < I18n::Backend::Simple
     include I18n::Backend::Fallbacks

--- a/test/locale/fallbacks_test.rb
+++ b/test/locale/fallbacks_test.rb
@@ -22,6 +22,13 @@ class I18nFallbacksDefaultsTest < I18n::TestCase
     assert_equal [:"de-CH", :de, :"en-GB", :en], fallbacks[:"de-CH"]
   end
 
+  test "explicit fallback to default locale" do
+    I18n.default_locale = :"en-US"
+    fallbacks = Fallbacks.new([:"en-US"])
+    assert_equal [:"de-AT", :de, :"en-US", :en], fallbacks[:"de-AT"]
+    assert_equal [:"de-CH", :de, :"en-US", :en], fallbacks[:"de-CH"]
+  end
+
   test "defaults reflect a manually passed default locale if any" do
     fallbacks = Fallbacks.new(:'fi-FI')
     assert_equal [:'fi-FI', :fi], fallbacks.defaults

--- a/test/locale/fallbacks_test.rb
+++ b/test/locale/fallbacks_test.rb
@@ -9,6 +9,19 @@ class I18nFallbacksDefaultsTest < I18n::TestCase
     assert_equal [], fallbacks.defaults
   end
 
+  test "documentation example #1 - does not use default locale in fallbacks - See Issues #413 & #415" do
+    I18n.default_locale = :"en-US"
+    fallbacks = Fallbacks.new(:"de-AT" => :"de-DE")
+    assert_equal [:"de-AT", :de, :"de-DE"], fallbacks[:"de-AT"]
+  end
+
+  test "documentation example #2 - does not use default locale in fallbacks - Uses custom locale - See Issues #413 & #415" do
+    I18n.default_locale = :"en-US"
+    fallbacks = Fallbacks.new(:"en-GB", :"de-AT" => :de, :"de-CH" => :de)
+    assert_equal [:"de-AT", :de, :"en-GB", :en], fallbacks[:"de-AT"]
+    assert_equal [:"de-CH", :de, :"en-GB", :en], fallbacks[:"de-CH"]
+  end
+
   test "defaults reflect a manually passed default locale if any" do
     fallbacks = Fallbacks.new(:'fi-FI')
     assert_equal [:'fi-FI', :fi], fallbacks.defaults

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,6 +34,7 @@ class I18n::TestCase < TEST_CASE
     I18n.backend = nil
     I18n.default_separator = nil
     I18n.enforce_available_locales = true
+    I18n.fallbacks = nil
     super
   end
 


### PR DESCRIPTION
Should fix #534. 