### PR TITLE
Enforce interpolation even the options is empty.

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -182,7 +182,7 @@ module I18n
         #   method interpolates ["yes, %{user}", ["maybe no, %{user}, "no, %{user}"]], :user => "bartuz"
         #   # => "["yes, bartuz",["maybe no, bartuz", "no, bartuz"]]"
         def interpolate(locale, subject, values = EMPTY_HASH)
-          return subject if values.empty?
+          return subject if values.empty? && !I18n.config.enforce_interpolation
 
           case subject
           when ::String then I18n.interpolate(subject, values)

--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -161,5 +161,30 @@ module I18n
     def interpolation_patterns=(interpolation_patterns)
       @@interpolation_patterns = interpolation_patterns
     end
+
+    # Enforce interpolation even the givien options is empty so that can
+    # trigger config.missing_interpolation_argument_handler.
+    #
+    # Defaults to false.
+    #
+    # E.g.
+    #
+    #    en:
+    #      test: "%{key} is missing!"
+    #
+    #    I18n.enforce_interpolation = false
+    #    I18n.t("test", key: "hello") # => "hello is missing!"
+    #    I18n.t("test") # => "%{key} is missing!"
+    #
+    #    I18n.enforce_interpolation = true
+    #    I18n.t("test") # => raise MissingInterpolationArgument (default handler)
+    @@enforce_interpolation = false
+    def enforce_interpolation
+      @@enforce_interpolation
+    end
+
+    def enforce_interpolation=(enforce_interpolation)
+      @@enforce_interpolation = enforce_interpolation
+    end
   end
 end

--- a/test/i18n/interpolate_test.rb
+++ b/test/i18n/interpolate_test.rb
@@ -54,6 +54,22 @@ class I18nInterpolateTest < I18n::TestCase
     assert_equal "%{num} %<num>d", I18n.interpolate("%%{num} %%<num>d", :num => 1)
   end
 
+  test "config enforce interpolation" do
+    store_translations(:en, "interpolation_missing" => '%{string} is missing')
+
+    prev_enforce_interpolation = I18n.config.enforce_interpolation
+    begin
+      I18n.config.enforce_interpolation = false
+      assert_equal("hello is missing", I18n.t("interpolation_missing", string: "hello"))
+      assert_nothing_raised { assert_equal("%{string} is missing", I18n.t("interpolation_missing")) }
+
+      I18n.config.enforce_interpolation = true
+      assert_raise(I18n::MissingInterpolationArgument) { I18n.t("interpolation_missing") }
+    ensure
+      I18n.config.enforce_interpolation = prev_enforce_interpolation
+    end
+  end
+
   def test_sprintf_mix_unformatted_and_formatted_named_placeholders
     assert_equal "foo 1.000000", I18n.interpolate("%{name} %<num>f", :name => "foo", :num => 1.0)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,7 +35,7 @@ class I18n::TestCase < TEST_CASE
     I18n.backend = nil
     I18n.default_separator = nil
     I18n.enforce_available_locales = true
-    I18n.fallbacks = nil
+    I18n.fallbacks = nil if I18n.respond_to?(:fallbacks=)
     super
   end
 


### PR DESCRIPTION
Currently, I'm working on internationalizing an exsiting project, I replaced a lot of hard-code text with `I18n.t`, but sometimes I forget to add proper interpolation options, and the translated text will be displayed as the original translation text in the YAML file.

So I want to have an option to enable the interpolation check in the dev/test/staging environments, then I can catch these errors in advance.