### PR TITLE
Should not allow noop arguments for `I18n.t`

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -192,7 +192,7 @@ module I18n
     #  I18n.t(:salutation, { :gender => 'w', :name => 'Smith' })
     #  I18n.t(:salutation, any_hash)
     #
-    def translate(key = nil, *, throw: false, raise: false, locale: nil, **options) # TODO deprecate :raise
+    def translate(key = nil, throw: false, raise: false, locale: nil, **options) # TODO deprecate :raise
       locale ||= config.locale
       raise Disabled.new('t') if locale == false
       enforce_available_locales!(locale)
@@ -217,8 +217,8 @@ module I18n
 
     # Wrapper for <tt>translate</tt> that adds <tt>:raise => true</tt>. With
     # this option, if no translation is found, it will raise <tt>I18n::MissingTranslationData</tt>
-    def translate!(key, options = EMPTY_HASH)
-      translate(key, **options.merge(:raise => true))
+    def translate!(key, **options)
+      translate(key, **options, raise: true)
     end
     alias :t! :translate!
 
@@ -281,7 +281,7 @@ module I18n
     #     I18n.transliterate("Jürgen") # => "Juergen"
     #     I18n.transliterate("Jürgen", :locale => :en) # => "Jurgen"
     #     I18n.transliterate("Jürgen", :locale => :de) # => "Juergen"
-    def transliterate(key, *, throw: false, raise: false, locale: nil, replacement: nil, **options)
+    def transliterate(key, throw: false, raise: false, locale: nil, replacement: nil, **options)
       locale ||= config.locale
       raise Disabled.new('transliterate') if locale == false
       enforce_available_locales!(locale)

--- a/test/api/override_test.rb
+++ b/test/api/override_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class I18nOverrideTest < I18n::TestCase
   module OverrideInverse
-    def translate(*args, **options)
-      super(*args, **options).reverse
+    def translate(key, **options)
+      super(key, **options).reverse
     end
     alias :t :translate
   end
@@ -33,7 +33,7 @@ class I18nOverrideTest < I18n::TestCase
 
   test "make sure modules can overwrite I18n signature" do
     exception = catch(:exception) do
-      @I18n.t('Hello', 'Welcome message on home page', :tokenize => true, :throw => true)
+      @I18n.t('Hello', :tokenize => true, :throw => true)
     end
     assert exception.message
     @I18n.extend OverrideSignature


### PR DESCRIPTION
Related #501, #500, and #471.

In Ruby 3.0, the behavior of `I18n.t("key", { value: "foo" })` has
silently changed to `{ value: "foo" }` is no longer regarded as
`**options` but regarded as noop slpat arguments `*`.

https://github.com/ruby-i18n/i18n/blob/4709391dceab9096d5988576f93935843023a6ef/lib/i18n.rb#L195

So allowing (discarding) noop arguments will be more harmful in Ruby 3.0.

This removes the allowing noop arguments, it makes `{ value: "foo" }`
will raise ArgumentError instead of silently ignored the options.