### PR TITLE
[WIP] Thread safe fallbacks

### DIFF
--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -16,11 +16,13 @@ module I18n
     # Returns the current fallbacks implementation. Defaults to +I18n::Locale::Fallbacks+.
     def fallbacks
       @@fallbacks ||= I18n::Locale::Fallbacks.new
+      Thread.current.fetch(:i18n_fallbacks, @@fallbacks)
     end
 
     # Sets the current fallbacks implementation. Use this to set a different fallbacks implementation.
     def fallbacks=(fallbacks)
       @@fallbacks = fallbacks.is_a?(Array) ? I18n::Locale::Fallbacks.new(fallbacks) : fallbacks
+      Thread.current[:i18n_fallbacks] = @@fallbacks
     end
   end
 

--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -16,7 +16,7 @@ module I18n
     # Returns the current fallbacks implementation. Defaults to +I18n::Locale::Fallbacks+.
     def fallbacks
       @@fallbacks ||= I18n::Locale::Fallbacks.new
-      Thread.current.key?(:i18n_fallbacks) ? Thread.current[:i18n_fallbacks] : @@fallbacks
+      Thread.current[:i18n_fallbacks] || @@fallbacks
     end
 
     # Sets the current fallbacks implementation. Use this to set a different fallbacks implementation.

--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -16,7 +16,7 @@ module I18n
     # Returns the current fallbacks implementation. Defaults to +I18n::Locale::Fallbacks+.
     def fallbacks
       @@fallbacks ||= I18n::Locale::Fallbacks.new
-      Thread.current.fetch(:i18n_fallbacks, @@fallbacks)
+      Thread.current.key?(:i18n_fallbacks) ? Thread.current[:i18n_fallbacks] : @@fallbacks
     end
 
     # Sets the current fallbacks implementation. Use this to set a different fallbacks implementation.

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -109,8 +109,18 @@ class I18nBackendFallbacksTranslateTest < I18n::TestCase
   end
 
   test "multi-threaded fallbacks" do
-    Thread.new do
+    I18n.fallbacks = [:en]
 
+    thread = Thread.new do
+      I18n.fallbacks = [:de]
+    end
+
+    begin
+      thread.join
+      assert_equal 'Bar in :en', I18n.t(:bar, :locale => :'pt-BR')
+    ensure
+      thread.exit
+      I18n.fallbacks = I18n::Locale::Fallbacks.new
     end
   end
 end


### PR DESCRIPTION
Thread safe fallbacks that does not cause #546. 

If this is not ideal, maybe we can introduce a new method `current_fallbacks=`, that sets the fallbacks for the current thread. 

What do you think about this @radar?