### PR TITLE
Move to OpenSSL Digest classes

### DIFF
--- a/lib/i18n/backend/cache.rb
+++ b/lib/i18n/backend/cache.rb
@@ -17,9 +17,9 @@
 #
 # The cache_key implementation by default assumes you pass values that return
 # a valid key from #hash (see
-# http://www.ruby-doc.org/core/classes/Object.html#M000337). However, you can
+# https://www.ruby-doc.org/core/classes/Object.html#M000337). However, you can
 # configure your own digest method via which responds to #hexdigest (see
-# http://ruby-doc.org/stdlib/libdoc/digest/rdoc/index.html):
+# https://ruby-doc.org/stdlib/libdoc/openssl/rdoc/OpenSSL/Digest.html):
 #
 #   I18n.cache_key_digest = OpenSSL::Digest::SHA256.new
 #

--- a/lib/i18n/backend/cache.rb
+++ b/lib/i18n/backend/cache.rb
@@ -21,7 +21,7 @@
 # configure your own digest method via which responds to #hexdigest (see
 # http://ruby-doc.org/stdlib/libdoc/digest/rdoc/index.html):
 #
-#   I18n.cache_key_digest = Digest::MD5.new
+#   I18n.cache_key_digest = OpenSSL::Digest::SHA256.new
 #
 # If you use a lambda as a default value in your translation like this:
 #

--- a/lib/i18n/backend/cache_file.rb
+++ b/lib/i18n/backend/cache_file.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'digest/sha2'
+require 'openssl'
 
 module I18n
   module Backend
@@ -19,7 +19,7 @@ module I18n
         key = I18n::Backend::Flatten.escape_default_separator(normalized_path(filename))
         old_mtime, old_digest = initialized && lookup(:i18n, key, :load_file)
         return if (mtime = File.mtime(filename).to_i) == old_mtime ||
-                  (digest = Digest::SHA2.file(filename).hexdigest) == old_digest
+                  (digest = OpenSSL::Digest::SHA256.file(filename).hexdigest) == old_digest
         super
         store_translations(:i18n, load_file: { key => [mtime, digest] })
       end

--- a/test/backend/cache_test.rb
+++ b/test/backend/cache_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require 'digest/md5'
+require 'openssl'
 
 begin
   require 'active_support'
@@ -74,11 +74,11 @@ class I18nBackendCacheTest < I18n::TestCase
   end
 
   test "cache_key uses configured digest method" do
-    md5 = Digest::MD5.new
+    digest = OpenSSL::Digest::SHA256.new
     options = { :bar => 1 }
     options_hash = options.inspect
-    with_cache_key_digest(md5) do
-      assert_equal "i18n//en/#{md5.hexdigest(:foo.to_s)}/#{md5.hexdigest(options_hash)}", I18n.backend.send(:cache_key, :en, :foo, options)
+    with_cache_key_digest(digest) do
+      assert_equal "i18n//en/#{digest.hexdigest(:foo.to_s)}/#{digest.hexdigest(options_hash)}", I18n.backend.send(:cache_key, :en, :foo, options)
     end
   end
 


### PR DESCRIPTION
In older Ruby versions, Digest uses legacy OpenSSL APIs to implement the digest methods. These APIs break in some configurations such as FIPS mode enforcement. In the latest Ruby, this was removed (see https://github.com/ruby/ruby/pull/3149), but that means Digest uses the non OpenSSL implementations. In those same environments that want FIPS enforcement, that is not desired as all crypto operations should be using OpenSSL there.

In https://github.com/ruby/openssl/pull/377, it is discussed to replace the constants when OpenSSL is loaded. But what is a limiting factor here, is that OpenSSL doesn't have the equivalent of Digest::SHA2 (which really ends up computing a SHA256 digest).

So this removes the usage of Digest::SHA2 which is harder to wrap and also recommends to use the OpenSSL digest by default.