### PR TITLE
Drop Ruby 1.8.7 support on require

### DIFF
--- a/test/backend/memoize_test.rb
+++ b/test/backend/memoize_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
-# TODO: change back to "require 'backend/simple'" when dropping support to Ruby 1.8.7.
-require File.expand_path('../simple_test', __FILE__)
+require 'backend/simple_test'
 
 class I18nBackendMemoizeTest < I18nBackendSimpleTest
   module MemoizeSpy


### PR DESCRIPTION
Now, Ruby 1.8.7 is not supported. So, I simply use require.

cf. https://github.com/ruby-i18n/i18n/commit/267b15b09ded951767e13cddcb0346b1ff5c9b93