### PR TITLE
Remove post_install_message

### DIFF
--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -28,23 +28,4 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'concurrent-ruby', '~> 1.0'
 
-  s.post_install_message = <<-END
-
-HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
-But that may break your application.
-
-If you are upgrading your Rails application from an older version of Rails:
-
-Please check your Rails app for 'config.i18n.fallbacks = true'.
-If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
-'config.i18n.fallbacks = [I18n.default_locale]'.
-If not, fallbacks will be broken in your app by I18n 1.1.x.
-
-If you are starting a NEW Rails application, you can ignore this notice.
-
-For more info see:
-https://github.com/svenfuchs/i18n/releases/tag/v1.1.0
-
-END
-
 end


### PR DESCRIPTION
## Why 

`config.i18n.fallbacks = true` is supported from rails `5.2.2` and onwards ([example](https://github.com/rails/rails/blob/94b5cd3a20edadd6f6b8cf0bdf1a4d4919df86cb/activesupport/lib/active_support/i18n_railtie.rb#L90-L91)). Having a warning message on install of the gem might confuse developers and end up in spending time checking the situation again and again for projects. 

## What

Since version of rails prior to 5.2.2 are [not supported any more](https://guides.rubyonrails.org/maintenance_policy.html), as only 5.2.4 is eligible for security fixes now, this message should not be relevant to many users. Would it be fine to just remove it? 🙏 

ref: https://github.com/ruby-i18n/i18n/pull/442