### PR TITLE
Update rails master to main

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,15 +22,15 @@ jobs:
             gemfiles/Gemfile.rails-5.2.x,
             gemfiles/Gemfile.rails-6.0.x,
             gemfiles/Gemfile.rails-6.1.x,
-            gemfiles/Gemfile.rails-master,
+            gemfiles/Gemfile.rails-main,
           ]
         exclude:
           # Ruby 3.x is not supported by Rails 5.2.x
           - ruby_version: 3.0.0
             gemfile: gemfiles/Gemfile.rails-5.2.x
-          # Ruby 2.4.x is not supported by Rails master
+          # Ruby 2.4.x is not supported by Rails main
           - ruby_version: 2.4.9
-            gemfile: gemfiles/Gemfile.rails-master
+            gemfile: gemfiles/Gemfile.rails-main
           # Ruby 2.4.x is not supported by Rails 6.1.x
           - ruby_version: 2.4.9
             gemfile: gemfiles/Gemfile.rails-6.1.x
@@ -40,15 +40,15 @@ jobs:
           # Ruby 2.3.x is not supported by Rails 6.1.x
           - ruby_version: 2.3.8
             gemfile: gemfiles/Gemfile.rails-6.1.x
-          # Ruby 2.3.x is not supported by Rails master
+          # Ruby 2.3.x is not supported by Rails main
           - ruby_version: 2.3.8
-            gemfile: gemfiles/Gemfile.rails-master
+            gemfile: gemfiles/Gemfile.rails-main
           # Ruby 2.3.x is not supported by Rails 6.0.x
           - ruby_version: 2.3.8
             gemfile: gemfiles/Gemfile.rails-6.0.x
-          # JRuby is not supported by Rails master
+          # JRuby is not supported by Rails main
           - ruby_version: jruby
-            gemfile: gemfiles/Gemfile.rails-master
+            gemfile: gemfiles/Gemfile.rails-main
 
     runs-on: ubuntu-latest
 

--- a/gemfiles/Gemfile.rails-main
+++ b/gemfiles/Gemfile.rails-main
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'activesupport', github: 'rails/rails', branch: 'master'
+gem 'activesupport', github: 'rails/rails', branch: 'main'
 gem 'mocha', '~> 1.7.0'
 gem 'test_declarative', '0.0.6'
 gem 'rake'


### PR DESCRIPTION
To correspond to the recent update:
https://weblog.rubyonrails.org/2021/1/24/this-week-in-rails-defaults-to-main-branch-name-new-webpacker-guide-and-improved-strict-loading/
https://github.com/rails/rails/commit/077c66d5d6ef3a6f1cc54e4a431bfa5ea6831b97