### PR TITLE
Prevent overwriting `Hash#except` method present in Ruby 3+

### DIFF
--- a/lib/i18n/core_ext/hash.rb
+++ b/lib/i18n/core_ext/hash.rb
@@ -4,7 +4,7 @@ module I18n
       using I18n::HashRefinements
       def except(*keys)
         dup.except!(*keys)
-      end
+      end unless method_defined?(:except)
 
       def except!(*keys)
         keys.each { |key| delete(key) }


### PR DESCRIPTION
_Note: this was updated to be based on https://github.com/ruby-i18n/i18n/pull/558 which fixes the build for the Rails main matrix._

Ruby 3+ introduced `Hash#except` method natively [1], so we can skip
I18n's custom implementation here if the method is already defined.
This follows the same Rails convention [2].

Note: This seems to be causing a `stack level too deep (SystemStackError)`
with a specific set of Gemfiles under Ruby 3, reported to `SimpleForm`
originally [3].  I haven't been able to fully narrow it down after some
initial investigation, nor reproduce it without the given set of gems in
the Gemfile reported, but it seems there's some interactions between
those gems, and combined with the fact that Ancestry loads I18n early on
to setup the load path [4], is possibly causing calls to `Hash#except`
to hang or raise with the `stack level too deep` error, and after
skipping the method re-declaration here it's not reproducible anymore.

[1] https://bugs.ruby-lang.org/issues/15822
[2] https://github.com/rails/rails/blob/5f3ff60084ab5d5921ca3499814e4697f8350ee7/activesupport/lib/active_support/core_ext/hash/except.rb#L12-L14
[3] https://github.com/heartcombo/simple_form/issues/1724
    steps to reproduce issue: https://github.com/heartcombo/simple_form/issues/1724#issuecomment-773722970
[4] https://github.com/stefankroes/ancestry/blob/71fe7042791f5943b5370240e4c6068dce73233d/lib/ancestry.rb#L9-L10

---

### Reproducing

_This is from the [original SimpleForm issue](https://github.com/heartcombo/simple_form/issues/1724#issuecomment-773722970)._

Minimal Gemfile used to reproduce:

```
source 'https://rubygems.org'
ruby '3.0.0'

gem 'rails', '~> 6.1.1'
gem 'sqlite3', '~> 1.4'
gem "puma"
gem "listen"

gem "ancestry", "3.2.1"
gem "simple_form", "5.0.3"
gem "hashie", "4.1.0"
gem "pry-byebug", "3.9.0"
```

Demo app: https://github.com/khustochka/sf_ancestry_test (I haven't tested this one directly myself, I had an app set up with that Gemfile above)

Simply going to `rails console` and typing `Hash.new.method(:except)` would hang, and running `rails server` would raise the stack error, without the change here. [More info about my testing](https://github.com/heartcombo/simple_form/issues/1724#issuecomment-774025784).