### PR TITLE
Build updates

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,6 +30,12 @@ jobs:
           # Ruby 3.x is not supported by Rails 5.2.x
           - ruby_version: 3.0
             gemfile: gemfiles/Gemfile.rails-5.2.x
+          # Ruby 2.6.x is not supported by Rails main
+          - ruby_version: 2.6
+            gemfile: gemfiles/Gemfile.rails-main
+          # Ruby 2.5.x is not supported by Rails main
+          - ruby_version: 2.5
+            gemfile: gemfiles/Gemfile.rails-main
           # Ruby 2.4.x is not supported by Rails main
           - ruby_version: 2.4
             gemfile: gemfiles/Gemfile.rails-main

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: [3.0.0, 2.7.1, 2.6.5, 2.5.7, 2.4.9, 2.3.8, jruby]
+        ruby_version: [3.0, 2.7, 2.6, 2.5, 2.4, 2.3, jruby]
         gemfile:
           [
             Gemfile,
@@ -28,25 +28,25 @@ jobs:
           ]
         exclude:
           # Ruby 3.x is not supported by Rails 5.2.x
-          - ruby_version: 3.0.0
+          - ruby_version: 3.0
             gemfile: gemfiles/Gemfile.rails-5.2.x
           # Ruby 2.4.x is not supported by Rails main
-          - ruby_version: 2.4.9
+          - ruby_version: 2.4
             gemfile: gemfiles/Gemfile.rails-main
           # Ruby 2.4.x is not supported by Rails 6.1.x
-          - ruby_version: 2.4.9
+          - ruby_version: 2.4
             gemfile: gemfiles/Gemfile.rails-6.1.x
           # Ruby 2.4.x is not supported by Rails 6.0.x
-          - ruby_version: 2.4.9
+          - ruby_version: 2.4
             gemfile: gemfiles/Gemfile.rails-6.0.x
           # Ruby 2.3.x is not supported by Rails 6.1.x
-          - ruby_version: 2.3.8
+          - ruby_version: 2.3
             gemfile: gemfiles/Gemfile.rails-6.1.x
           # Ruby 2.3.x is not supported by Rails main
-          - ruby_version: 2.3.8
+          - ruby_version: 2.3
             gemfile: gemfiles/Gemfile.rails-main
           # Ruby 2.3.x is not supported by Rails 6.0.x
-          - ruby_version: 2.3.8
+          - ruby_version: 2.3
             gemfile: gemfiles/Gemfile.rails-6.0.x
           # JRuby is not supported by Rails main
           - ruby_version: jruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,6 +30,12 @@ jobs:
           # Ruby 3.x is not supported by Rails 5.2.x
           - ruby_version: 3.0
             gemfile: gemfiles/Gemfile.rails-5.2.x
+          # Ruby 3.x is not supported by Rails 5.1.x
+          - ruby_version: 3.0
+            gemfile: gemfiles/Gemfile.rails-5.1.x
+          # Ruby 3.x is not supported by Rails 5.0.x
+          - ruby_version: 3.0
+            gemfile: gemfiles/Gemfile.rails-5.0.x
           # Ruby 2.6.x is not supported by Rails main
           - ruby_version: 2.6
             gemfile: gemfiles/Gemfile.rails-main


### PR DESCRIPTION
- Rails main now targets version 7.0, and with that it supports Ruby 2.7+ only
  - These failures happened on my other PR: https://github.com/ruby-i18n/i18n/pull/557, so I thought I'd create a separate one to tackle this instead of bundling it all together.
- Exclude Ruby 3 + Rails 5.x from test matrix (it appears 5.0 & 5.1 were passing there, but Ruby 3 is not officially supported there anyway and 5.2 was already excluded, so I thought it'd make sense to just not support Ruby 3 on Rails < 6 officially)
- Run tests on the latest patch versions of each Ruby release