### PR TITLE
Fix string locale will trigger on_fallback hook.

### DIFF
--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -49,7 +49,7 @@ module I18n
             catch(:exception) do
               result = super(fallback, key, fallback_options)
               unless result.nil?
-                on_fallback(locale, fallback, key, options) if locale != fallback
+                on_fallback(locale, fallback, key, options) if locale.to_s != fallback.to_s
                 return result
               end
             end

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -342,4 +342,9 @@ class I18nBackendOnFallbackHookTest < I18n::TestCase
     assert_equal [:'de-DE', :de, :bar, {}], I18n.backend.fallback_collector[0]
     assert_equal [:'de-DE', :en, :foo, {}], I18n.backend.fallback_collector[1]
   end
+
+  test "on_fallback should not be called when use a String locale" do
+    assert_equal 'Bar in :de', I18n.t("bar", locale: "de")
+    assert I18n.backend.fallback_collector.nil?
+  end
 end


### PR DESCRIPTION
When I use the `on_fallback` hook (introduced by https://github.com/ruby-i18n/i18n/pull/520), I found it would be triggered unexpectedly when given a string locale value.

e.g.
```
I18n.t("hello", locale: :"zh-CN") # Symbol locale value, won't trigger `on_fallback` hook.
I18n.t("hello", locale: "zh-CN") # String locale value, would trigger `on_fallback` hook.
```

This PR tries to fix it.