### PR TITLE
Improve available locale check in Simple backend

### DIFF
--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -35,8 +35,7 @@ module I18n
         def store_translations(locale, data, options = EMPTY_HASH)
           if I18n.enforce_available_locales &&
             I18n.available_locales_initialized? &&
-            !I18n.available_locales.include?(locale.to_sym) &&
-            !I18n.available_locales.include?(locale.to_s)
+            !I18n.locale_available?(locale)
             return data
           end
           locale = locale.to_sym


### PR DESCRIPTION
This reduces some duplication in the `Simple` backend by leveraging an existing check (added in https://github.com/ruby-i18n/i18n/commit/3b6e56e06fd70f6e4507996b017238505e66608c) that will validate either a string and symbol `locale` against a set of those that are locales available.

This should also improve the performance of related lookups (following https://github.com/ruby-i18n/i18n/commit/a65fffd6f0472bc413ba41809dafc6292e29d2ae)