### PR TITLE
Fix a build error when using Psych 4.0

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -240,7 +240,11 @@ module I18n
         # toplevel keys.
         def load_yml(filename)
           begin
-            YAML.load_file(filename)
+            if YAML.respond_to?(:unsafe_load_file) # Psych 4.0 way
+              YAML.unsafe_load_file(filename)
+            else
+              YAML.load_file(filename)
+            end
           rescue TypeError, ScriptError, StandardError => e
             raise InvalidLocaleData.new(filename, e.inspect)
           end


### PR DESCRIPTION
This PR fixes the following build error when using Psych 4.0.

```console
% ruby -v
ruby 3.1.0dev (2021-05-17T10:51:51Z master ee611341c9) [x86_64-darwin19]

% cd path/to/i18n

% bundle exec rake
(snip)

Finished in 1.310478s, 1265.1872 runs/s, 2004.6121 assertions/s.

  1) Error:
KeyValueCacheFileTest#test_load_translations_caches_file_through_updated_modification_time:
I18n::InvalidLocaleData: can not load translations from
/var/folders/6j/5l8q3y250b97529_tcssrwlm0000gn/T/test20210528-81604-ijnu7v.yml:
#<Psych::DisallowedClass: Tried to load unspecified class: Symbol>
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/base.rb:245:in
    `rescue in load_yml'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/base.rb:241:in
    `load_yml'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/base.rb:226:in
    `load_file'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/cache_file.rb:23:in
    `load_file'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/base.rb:18:in
    `block in load_translations'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/base.rb:18:in
    `each'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/base.rb:18:in
    `load_translations'
    /Users/koic/src/github.com/ruby-i18n/i18n/test/backend/cache_file_test.rb:49:in
    `block (2 levels) in <module:CacheFileTest>'
    /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/tempfile.rb:317:in
    `open'
    /Users/koic/src/github.com/ruby-i18n/i18n/test/backend/cache_file_test.rb:43:in
    `block in <module:CacheFileTest>'

  2) Error:
SimpleCacheFileTest#test_load_translations_caches_file_through_updated_modification_time:
I18n::InvalidLocaleData: can not load translations from
/var/folders/6j/5l8q3y250b97529_tcssrwlm0000gn/T/test20210528-81604-9kcvkm.yml:
#<Psych::DisallowedClass: Tried to load unspecified class: Symbol>
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/base.rb:245:in
    `rescue in load_yml'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/base.rb:241:in
    `load_yml'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/base.rb:226:in
    `load_file'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/cache_file.rb:23:in
    `load_file'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/base.rb:18:in
    `block in load_translations'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/base.rb:18:in
    `each'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/base.rb:18:in
    `load_translations'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/simple.rb:79:in
    `init_translations'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/simple.rb:89:in
    `lookup'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n/backend/base.rb:32:in
    `translate'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n.rb:207:in `block
    in translate'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n.rb:203:in `catch'
    /Users/koic/src/github.com/ruby-i18n/i18n/lib/i18n.rb:203:in
    `translate'
    /Users/koic/src/github.com/ruby-i18n/i18n/test/backend/cache_file_test.rb:50:in
    `block (2 levels) in <module:CacheFileTest>'
    /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/tempfile.rb:317:in
    `open'
    /Users/koic/src/github.com/ruby-i18n/i18n/test/backend/cache_file_test.rb:43:in
    `block in <module:CacheFileTest>'

1658 runs, 2627 assertions, 0 failures, 2 errors, 0 skips
rake aborted!
```

This breaking is because an incompatibility with Psych 4.0.

- https://github.com/ruby/psych/pull/487
- https://bugs.ruby-lang.org/issues/17866

For example, this PR solves the problem of faker gem that depend on i18n gem.
https://github.com/faker-ruby/faker/issues/2330