### PR TITLE
Fix ArgumentError when Fallbacks#map used as in Hash

### DIFF
--- a/lib/i18n/locale/fallbacks.rb
+++ b/lib/i18n/locale/fallbacks.rb
@@ -71,13 +71,18 @@ module I18n
         super || store(locale, compute(locale))
       end
 
-      def map(mappings)
-        mappings.each do |from, to|
-          from, to = from.to_sym, Array(to)
-          to.each do |_to|
-            @map[from] ||= []
-            @map[from] << _to.to_sym
+      def map(*args, &block)
+        if args.count == 1 && !block_given?
+          mappings = args.first
+          mappings.each do |from, to|
+            from, to = from.to_sym, Array(to)
+            to.each do |_to|
+              @map[from] ||= []
+              @map[from] << _to.to_sym
+            end
           end
+        else
+          @map.map(*args, &block)
         end
       end
 

--- a/test/locale/fallbacks_test.rb
+++ b/test/locale/fallbacks_test.rb
@@ -159,3 +159,15 @@ class I18nFallbacksComputationTest < I18n::TestCase
     end
   end
 end
+
+class I18nFallbacksHashCompatibilityTest < I18n::TestCase
+  def setup
+    super
+    @fallbacks = Fallbacks.new(:'en-US', :"de-AT" => :"de-DE")
+  end
+
+  test "map is compatible with Hash#map" do
+    result = @fallbacks.map { |key, value| [key, value] }
+    assert_equal([[:"de-AT", [:"de-DE"]]], result)
+  end
+end


### PR DESCRIPTION
This can cause a problem with Airbrake when a Fallbacks instance is set as a thread-local variable like this:

```
Thread.current[:foo] = I18n::Locale::Fallbacks.new(:"de-AT" => :de)
notice = Airbrake.build_notice("hi")
Airbrake::Filters::ThreadFilter.new.call(notice)
```

Airbrake tries to sanitize the instance, and as it `is_a?(Hash)` it tries to call map on it with 0 arguments and a block, which raises:

```
ArgumentError: wrong number of arguments (given 0, expected 1) from
gems/i18n-1.8.10/lib/i18n/locale/fallbacks.rb:74:in `map'
```