### PR TITLE
Fix typo in Simple backend JSON test

### DIFF
--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -76,7 +76,7 @@ class I18nBackendSimpleTest < I18n::TestCase
   end
 
   test "simple load_json: loads data from a JSON file" do
-    data = I18n.backend.send(:load_yml, "#{locales_dir}/en.json")
+    data = I18n.backend.send(:load_json, "#{locales_dir}/en.json")
     assert_equal({ 'en' => { 'foo' => { 'bar' => 'baz' } } }, data)
   end
 


### PR DESCRIPTION
Originally added in https://github.com/ruby-i18n/i18n/pull/429/commits/ebcd95ac57254bc2dbb83991ceca88ff0d223bcf

Noticed / noted a few weeks ago (https://github.com/ruby-i18n/i18n/pull/429#discussion_r652139035) as a typo, this fixes the test to align with what's intended to be tested here.