### PR TITLE
Fix missing requires of i18n/core_ext/hash

### DIFF
--- a/lib/i18n/backend/chain.rb
+++ b/lib/i18n/backend/chain.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'i18n/core_ext/hash'
+
 module I18n
   module Backend
     # Backend that chains multiple other backends and checks each of them when

--- a/lib/i18n/backend/gettext.rb
+++ b/lib/i18n/backend/gettext.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'i18n/core_ext/hash'
 require 'i18n/gettext'
 require 'i18n/gettext/po_parser'
 

--- a/test/backend/chain_test.rb
+++ b/test/backend/chain_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'i18n/backend/chain'
 
 class I18nBackendChainTest < I18n::TestCase
   def setup

--- a/test/gettext/backend_test.rb
+++ b/test/gettext/backend_test.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'test_helper'
+require 'i18n/backend/gettext'
 
 class I18nGettextBackendTest < I18n::TestCase
   include I18n::Gettext::Helpers


### PR DESCRIPTION
If you try to build a custom i18n backend using chain in a rails initialiser it requires only chain file but breaks with `uninitialized constant I18n::HashRefinements`

This cannot be reproduced during just `rake test` because file gets loaded, but I added explicit requires to test to reproduce failure if you stash `lib` changes:

```
$ rake test TEST=test/backend/chain_test.rb                                                                                                                                                     ​
...
i18n/lib/i18n/backend/chain.rb:20:in `<class:Chain>': uninitialized constant I18n::HashRefinements (NameError)
	from i18n/lib/i18n/backend/chain.rb:19:in `<module:Backend>'
      ​....
rake aborted!
...
```
same  for  `rake test TEST=test/gettext/backend_test.rb`