### PR TITLE
Remove references to `default_locale` in fallbacks comment

### DIFF
--- a/lib/i18n/locale/fallbacks.rb
+++ b/lib/i18n/locale/fallbacks.rb
@@ -15,18 +15,11 @@
 #   * all parent locales of a given locale (e.g. :es for :"es-MX") first,
 #   * the current default locales and all of their parents second
 #
-# The default locales are set to [I18n.default_locale] by default but can be
-# set to something else.
+# The default locales are set to [] by default but can be set to something else.
 #
 # One can additionally add any number of additional fallback locales manually.
 # These will be added before the default locales to the fallback chain. For
 # example:
-#
-#   # using the default locale as default fallback locale
-#
-#   I18n.default_locale = :"en-US"
-#   I18n.fallbacks = I18n::Locale::Fallbacks.new(:"de-AT" => :"de-DE")
-#   I18n.fallbacks[:"de-AT"] # => [:"de-AT", :de, :"de-DE"]
 #
 #   # using a custom locale as default fallback locale
 #


### PR DESCRIPTION
### What are you trying to accomplish?

https://github.com/ruby-i18n/i18n/pull/415 changed the behaviour, but this comment was not updated to reflect the change.

### What approach did you choose and why?

Minimal changes to the documentation comment.

### What should reviewers focus on?

I don't have the depth of knowledge in this area to know if there is more that should change in this comment.

### The impact of these changes

People will hopefully get less confused when they read the comment (won't go looking for some non-existent code somehow using the `default_locale`).

cc @radar 

### Checklist
- [x] This PR is safe to roll back.