### PR TITLE
API for marking a key as reserved

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -29,12 +29,24 @@ module I18n
     scope
     separator
     throw
-  ].freeze
-  RESERVED_KEYS_PATTERN = /%\{(#{RESERVED_KEYS.join("|")})\}/
+  ]
   EMPTY_HASH = {}.freeze
 
   def self.new_double_nested_cache # :nodoc:
     Concurrent::Map.new { |h, k| h[k] = Concurrent::Map.new }
+  end
+
+  # Marks a key as reserved. Reserved keys are used internally,
+  # and can't also be used for interpolation. If you are using any
+  # extra keys as I18n options, you should call I18n.reserve_key
+  # before any I18n.translate (etc) calls are made.
+  def self.reserve_key(key)
+    RESERVED_KEYS << key.to_sym
+    @reserved_keys_pattern = nil
+  end
+
+  def self.reserved_keys_pattern # :nodoc:
+    @reserved_keys_pattern ||= /%\{(#{RESERVED_KEYS.join("|")})\}/
   end
 
   module Base

--- a/lib/i18n/interpolate/ruby.rb
+++ b/lib/i18n/interpolate/ruby.rb
@@ -14,7 +14,7 @@ module I18n
     # Return String or raises MissingInterpolationArgument exception.
     # Missing argument's logic is handled by I18n.config.missing_interpolation_argument_handler.
     def interpolate(string, values)
-      raise ReservedInterpolationKey.new($1.to_sym, string) if string =~ RESERVED_KEYS_PATTERN
+      raise ReservedInterpolationKey.new($1.to_sym, string) if string =~ I18n.reserved_keys_pattern
       raise ArgumentError.new('Interpolation values must be a Hash.') unless values.kind_of?(Hash)
       interpolate_hash(string, values)
     end

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -487,4 +487,22 @@ class I18nTest < I18n::TestCase
       I18n.enforce_available_locales = false
     end
   end
+
+  test "can reserve a key" do
+    begin
+      reserved_keys_were = I18n::RESERVED_KEYS.dup
+
+      assert !I18n::RESERVED_KEYS.include?(:foo)
+      assert !I18n::RESERVED_KEYS.include?(:bar)
+
+      I18n.reserve_key(:foo)
+      I18n.reserve_key("bar")
+
+      assert I18n::RESERVED_KEYS.include?(:foo)
+      assert I18n::RESERVED_KEYS.include?(:bar)
+    ensure
+      I18n::RESERVED_KEYS = reserved_keys_were
+      I18n.instance_variable_set(:@reserved_keys_pattern, nil)
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/ruby-i18n/i18n/issues/577

If you have a key you want to use as an option in `I18n.t` calls (*not* as an interpolation key), you can do this in an initializer:

```ruby
I18n.reserve_key(:my_special_option)
```