### PR TITLE
Exclude MissingTranslation options that are not used by the instance

### DIFF
--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -47,10 +47,12 @@ module I18n
 
   class MissingTranslation < ArgumentError
     module Base
+      PERMITTED_KEYS = [:scope].freeze
+
       attr_reader :locale, :key, :options
 
       def initialize(locale, key, options = EMPTY_HASH)
-        @key, @locale, @options = key, locale, options.dup
+        @key, @locale, @options = key, locale, options.slice(*PERMITTED_KEYS)
         options.each { |k, v| self.options[k] = v.inspect if v.is_a?(Proc) }
       end
 

--- a/test/backend/cache_test.rb
+++ b/test/backend/cache_test.rb
@@ -58,6 +58,14 @@ class I18nBackendCacheTest < I18n::TestCase
     # assert_raise(I18n::MissingTranslationData) { I18n.t(:missing, :raise => true) }
   end
 
+  test "MissingTranslationData does not cache custom options" do
+    I18n.t(:missing, :scope => :foo, :extra => true)
+    assert_equal 1, I18n.cache_store.instance_variable_get(:@data).size
+
+    cache_key, entry = I18n.cache_store.instance_variable_get(:@data).first
+    assert_equal({ scope: :foo }, entry.value.options)
+  end
+
   test "uses 'i18n' as a cache key namespace by default" do
     assert_equal 0, I18n.backend.send(:cache_key, :en, :foo, {}).index('i18n')
   end


### PR DESCRIPTION
Fixes #580

Instances of MissingTranslation are currently initialized with the options originally passed to `I18n.translate`.
When using ActiveRecord those options will include a reference to the instance.
And when combined with a (Rails) cache store, that MissingTranslation instance is now expected to work with Marshal.dump.

The only MissingTranslation option being used appears to be `:scope`; when converting the instance to a string, so that key is kept.