### PR TITLE
CI: ruby/setup-ruby with cache

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,10 +12,12 @@ on:
 
 jobs:
   build:
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: [3.0, 2.7, 2.6, 2.5, 2.4, 2.3, jruby]
+        ruby_version: ["3.0", 2.7, 2.6, 2.5, 2.4, 2.3, jruby]
         gemfile:
           [
             Gemfile,
@@ -69,13 +71,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
-        uses: eregon/use-ruby-action@master
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true # 'bundle install' and cache
       - name: Build and test with Rake
-        env:
-          BUNDLE_GEMFILE: ${{ matrix.gemfile }}
-        run: |
-          gem install bundler
-          bundle install --jobs 4 --retry 3
-          bundle exec rake
+        run: bundle exec rake


### PR DESCRIPTION
This PR changes the Action used to the Ruby-developed `setup-ruby`, and enables its Bundler installation and caching.

After a few false starts, it works. Example run: https://github.com/olleolleolle/i18n/actions/runs/1415651152

---

Oh, a note about the quoted 3.0:

This is a very small change, but which avoids a Float-to-String loss of characters.

An example (not from this project) of what it can look like before this change, in this picture:

<img width="376" alt="bild" src="https://user-images.githubusercontent.com/211/119782378-6ad6cd00-becc-11eb-9e13-9a425adaa054.png">

Read more details, if you like: https://github.com/actions/runner/issues/849