### PR TITLE
Symbolize keys and freeze values when loading from YAML

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -240,7 +240,7 @@ module I18n
         def load_yml(filename)
           begin
             if YAML.respond_to?(:unsafe_load_file) # Psych 4.0 way
-              [YAML.unsafe_load_file(filename), false]
+              [YAML.unsafe_load_file(filename, symbolize_names: true, freeze: true), true]
             else
               [YAML.load_file(filename), false]
             end

--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -255,7 +255,7 @@ module I18n
         def load_json(filename)
           begin
             # Use #load_file as a proxy for a version of JSON where symbolize_names and freeze are supported.
-            if JSON.respond_to?(:load_file)
+            if ::JSON.respond_to?(:load_file)
               [::JSON.load_file(filename, symbolize_names: true, freeze: true), true]
             else
               [::JSON.parse(File.read(filename)), false]

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -97,10 +97,12 @@ class I18nBackendSimpleTest < I18n::TestCase
 
   test "simple load_json: loads data from a JSON file" do
     data, _ = I18n.backend.send(:load_json, "#{locales_dir}/en.json")
-    assert_equal({ :en => { :foo => { :bar => 'baz' } } }, data)
 
     if JSON.respond_to?(:load_file)
+      assert_equal({ :en => { :foo => { :bar => 'baz' } } }, data)
       assert_predicate data.dig(:en, :foo, :bar), :frozen?
+    else
+      assert_equal({ 'en' => { 'foo' => { 'bar' => 'baz' } } }, data)
     end
   end
 

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -92,7 +92,12 @@ class I18nBackendSimpleTest < I18n::TestCase
 
   test "simple load_yml: loads data from a YAML file" do
     data, _ = I18n.backend.send(:load_yml, "#{locales_dir}/en.yml")
-    assert_equal({ 'en' => { 'foo' => { 'bar' => 'baz' } } }, data)
+    if ::YAML.respond_to?(:unsafe_load_file)
+      assert_equal({ :en => { :foo => { :bar => 'baz' } } }, data)
+      assert_predicate data.dig(:en, :foo, :bar), :frozen?
+    else
+      assert_equal({ 'en' => { 'foo' => { 'bar' => 'baz' } } }, data)
+    end
   end
 
   test "simple load_json: loads data from a JSON file" do


### PR DESCRIPTION
#### Changes introduced

[Pysch](https://github.com/ruby/pysch), Ruby's YAML parser, now [supports](https://github.com/ruby/psych/pull/414) configuring `freeze` and `symbolize_names` as options for `YAML#unsafe_load_file` and `YAML#load_file`.

This PR sets both of these parameters to true.

#### Intended outcomes

In setting `freeze: true`, all values returned will now be frozen objects. Further, string values will be deduplicated.

In setting `symbolize_names: true`, keys will be directly parsed as symbols. This is particularly beneficial, as [we already eventually perform a call to `#deep_symbolize_keys`](https://github.com/ruby-i18n/i18n/blob/95612def98cb9c1d5be660aa77062c9be0b0430c/lib/i18n/backend/simple.rb#L43). This way, they'll take on their `Symbol` representation at parse-time.