### PR TITLE
Fix typo: function is missing closing parenthesis

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -261,14 +261,14 @@ module I18n
     #
     # Setting a Hash using Ruby:
     #
-    #     store_translations(:de, :i18n => {
-    #       :transliterate => {
-    #         :rule => {
-    #           "ü" => "ue",
-    #           "ö" => "oe"
-    #         }
-    #       }
-    #     })
+    #     store_translations(:de, i18n: {
+    #                          transliterate: {
+    #                            rule: {
+    #                              'ü' => 'ue',
+    #                              'ö' => 'oe'
+    #                            }
+    #                          }
+    #                        })
     #
     # Setting a Proc:
     #

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -268,7 +268,7 @@ module I18n
     #           "ö" => "oe"
     #         }
     #       }
-    #     )
+    #     })
     #
     # Setting a Proc:
     #


### PR DESCRIPTION
Fixes typo for 'store_translations' function - issue [#575](https://github.com/ruby-i18n/i18n/issues/575)