### PR TITLE
Symbolize names and freeze values when loading from JSON

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -253,7 +253,12 @@ module I18n
         # toplevel keys.
         def load_json(filename)
           begin
-            ::JSON.parse(File.read(filename))
+            # Use #load_file as a proxy for a version of JSON where symbolize_names and freeze are supported.
+            if JSON.respond_to?(:load_file)
+              ::JSON.load_file(filename, symbolize_names: true, freeze: true)
+            else
+              ::JSON.parse(File.read(filename))
+            end
           rescue TypeError, StandardError => e
             raise InvalidLocaleData.new(filename, e.inspect)
           end

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -77,7 +77,11 @@ class I18nBackendSimpleTest < I18n::TestCase
 
   test "simple load_json: loads data from a JSON file" do
     data = I18n.backend.send(:load_json, "#{locales_dir}/en.json")
-    assert_equal({ 'en' => { 'foo' => { 'bar' => 'baz' } } }, data)
+    assert_equal({ :en => { :foo => { :bar => 'baz' } } }, data)
+
+    if JSON.respond_to?(:load_file)
+      assert_predicate data.dig(:en, :foo, :bar), :frozen?
+    end
   end
 
   test "simple load_translations: loads data from known file formats" do


### PR DESCRIPTION
Following [a comment](https://github.com/ruby-i18n/i18n/pull/583#issuecomment-975667482) in #583, this PR uses new options in [JSON](https://github.com/flori/json) to freeze and symbolize names at parse time.

I can append this commit to the other PR if that'd make it easier, but I opted to keep PRs as granular as possible for ease of review.