### PR TITLE
Clean up unneeded test aliases 

### DIFF
--- a/lib/i18n/tests/defaults.rb
+++ b/lib/i18n/tests/defaults.rb
@@ -37,7 +37,7 @@ module I18n
       end
 
       test "defaults: given an array of missing keys it raises a MissingTranslationData exception" do
-        assert_raise I18n::MissingTranslationData do
+        assert_raises I18n::MissingTranslationData do
           I18n.t(:does_not_exist, :default => [:does_not_exist_2, :does_not_exist_3], :raise => true)
         end
       end

--- a/lib/i18n/tests/interpolation.rb
+++ b/lib/i18n/tests/interpolation.rb
@@ -41,7 +41,7 @@ module I18n
       end
 
       test "interpolation: given values but missing a key it raises I18n::MissingInterpolationArgument" do
-        assert_raise(I18n::MissingInterpolationArgument) do
+        assert_raises(I18n::MissingInterpolationArgument) do
           interpolate(:default => '%{foo}', :bar => 'bar')
         end
       end
@@ -77,13 +77,13 @@ module I18n
 
       if Object.const_defined?(:Encoding)
         test "interpolation: given a euc-jp translation and a utf-8 value it raises Encoding::CompatibilityError" do
-          assert_raise(Encoding::CompatibilityError) do
+          assert_raises(Encoding::CompatibilityError) do
             interpolate(:default => euc_jp('こんにちは、%{name}さん!'), :name => 'ゆきひろ')
           end
         end
 
         test "interpolation: given a utf-8 translation and a euc-jp value it raises Encoding::CompatibilityError" do
-          assert_raise(Encoding::CompatibilityError) do
+          assert_raises(Encoding::CompatibilityError) do
             interpolate(:default => 'こんにちは、%{name}さん!', :name => euc_jp('ゆきひろ'))
           end
         end
@@ -108,10 +108,10 @@ module I18n
       end
 
       test "interpolation: given a translations containing a reserved key it raises I18n::ReservedInterpolationKey" do
-        assert_raise(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{exception_handler}') }
-        assert_raise(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{default}') }
-        assert_raise(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{separator}') }
-        assert_raise(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{scope}') }
+        assert_raises(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{exception_handler}') }
+        assert_raises(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{default}') }
+        assert_raises(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{separator}') }
+        assert_raises(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{scope}') }
       end
 
       test "interpolation: deep interpolation for default string" do

--- a/lib/i18n/tests/localization/date.rb
+++ b/lib/i18n/tests/localization/date.rb
@@ -78,15 +78,15 @@ module I18n
         end
 
         test "localize Date: given nil it raises I18n::ArgumentError" do
-          assert_raise(I18n::ArgumentError) { I18n.l(nil) }
+          assert_raises(I18n::ArgumentError) { I18n.l(nil) }
         end
 
         test "localize Date: given a plain Object it raises I18n::ArgumentError" do
-          assert_raise(I18n::ArgumentError) { I18n.l(Object.new) }
+          assert_raises(I18n::ArgumentError) { I18n.l(Object.new) }
         end
 
         test "localize Date: given a format is missing it raises I18n::MissingTranslationData" do
-          assert_raise(I18n::MissingTranslationData) { I18n.l(@date, :format => :missing) }
+          assert_raises(I18n::MissingTranslationData) { I18n.l(@date, :format => :missing) }
         end
 
         test "localize Date: it does not alter the format string" do

--- a/lib/i18n/tests/localization/date_time.rb
+++ b/lib/i18n/tests/localization/date_time.rb
@@ -78,7 +78,7 @@ module I18n
         end
 
         test "localize DateTime: given a format is missing it raises I18n::MissingTranslationData" do
-          assert_raise(I18n::MissingTranslationData) { I18n.l(@datetime, :format => :missing) }
+          assert_raises(I18n::MissingTranslationData) { I18n.l(@datetime, :format => :missing) }
         end
 
         protected

--- a/lib/i18n/tests/localization/time.rb
+++ b/lib/i18n/tests/localization/time.rb
@@ -79,7 +79,7 @@ module I18n
         end
 
         test "localize Time: given a format is missing it raises I18n::MissingTranslationData" do
-          assert_raise(I18n::MissingTranslationData) { I18n.l(@time, :format => :missing) }
+          assert_raises(I18n::MissingTranslationData) { I18n.l(@time, :format => :missing) }
         end
 
         protected

--- a/lib/i18n/tests/lookup.rb
+++ b/lib/i18n/tests/lookup.rb
@@ -34,7 +34,7 @@ module I18n
       end
 
       test "lookup: given a missing key, no default and the raise option it raises MissingTranslationData" do
-        assert_raise(I18n::MissingTranslationData) { I18n.t(:missing, :raise => true) }
+        assert_raises(I18n::MissingTranslationData) { I18n.t(:missing, :raise => true) }
       end
 
       test "lookup: does not raise an exception if no translation data is present for the given locale" do
@@ -61,7 +61,7 @@ module I18n
       # In fact it probably *should* fail but Rails currently relies on using the default locale instead.
       # So we'll stick to this for now until we get it fixed in Rails.
       test "lookup: given nil as a locale it does not raise but use the default locale" do
-        # assert_raise(I18n::InvalidLocale) { I18n.t(:bar, :locale => nil) }
+        # assert_raises(I18n::InvalidLocale) { I18n.t(:bar, :locale => nil) }
         assert_nothing_raised { I18n.t(:bar, :locale => nil) }
       end
 

--- a/lib/i18n/tests/pluralization.rb
+++ b/lib/i18n/tests/pluralization.rb
@@ -28,7 +28,7 @@ module I18n
       end
 
       test "pluralization: given incomplete pluralization data it raises I18n::InvalidPluralizationData" do
-        assert_raise(I18n::InvalidPluralizationData) { I18n.t(:default => { :one => 'bar' }, :count => 2) }
+        assert_raises(I18n::InvalidPluralizationData) { I18n.t(:default => { :one => 'bar' }, :count => 2) }
       end
     end
   end

--- a/test/backend/cache_test.rb
+++ b/test/backend/cache_test.rb
@@ -48,14 +48,14 @@ class I18nBackendCacheTest < I18n::TestCase
   end
 
   test "still raises MissingTranslationData but also caches it" do
-    assert_raise(I18n::MissingTranslationData) { I18n.t(:missing, :raise => true) }
-    assert_raise(I18n::MissingTranslationData) { I18n.t(:missing, :raise => true) }
+    assert_raises(I18n::MissingTranslationData) { I18n.t(:missing, :raise => true) }
+    assert_raises(I18n::MissingTranslationData) { I18n.t(:missing, :raise => true) }
     assert_equal 1, I18n.cache_store.instance_variable_get(:@data).size
 
     # I18n.backend.expects(:lookup).returns(nil)
-    # assert_raise(I18n::MissingTranslationData) { I18n.t(:missing, :raise => true) }
+    # assert_raises(I18n::MissingTranslationData) { I18n.t(:missing, :raise => true) }
     # I18n.backend.expects(:lookup).never
-    # assert_raise(I18n::MissingTranslationData) { I18n.t(:missing, :raise => true) }
+    # assert_raises(I18n::MissingTranslationData) { I18n.t(:missing, :raise => true) }
   end
 
   test "uses 'i18n' as a cache key namespace by default" do

--- a/test/backend/cascade_test.rb
+++ b/test/backend/cascade_test.rb
@@ -29,9 +29,9 @@ class I18nBackendCascadeTest < I18n::TestCase
   end
 
   test "raises I18n::MissingTranslationData exception when no translation was found" do
-    assert_raise(I18n::MissingTranslationData) { lookup(:'foo.missing', :raise => true) }
-    assert_raise(I18n::MissingTranslationData) { lookup(:'bar.baz.missing', :raise => true) }
-    assert_raise(I18n::MissingTranslationData) { lookup(:'missing.bar.baz', :raise => true) }
+    assert_raises(I18n::MissingTranslationData) { lookup(:'foo.missing', :raise => true) }
+    assert_raises(I18n::MissingTranslationData) { lookup(:'bar.baz.missing', :raise => true) }
+    assert_raises(I18n::MissingTranslationData) { lookup(:'missing.bar.baz', :raise => true) }
   end
 
   test "cascades before evaluating the default" do

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -82,12 +82,12 @@ class I18nBackendFallbacksTranslateTest < I18n::TestCase
   end
 
   test "raises I18n::MissingTranslationData exception when fallback is disabled even when fallback translation exists" do
-    assert_raise(I18n::MissingTranslationData) { I18n.t(:foo, :locale => :de, :fallback => false, :raise => true) }
+    assert_raises(I18n::MissingTranslationData) { I18n.t(:foo, :locale => :de, :fallback => false, :raise => true) }
   end
 
   test "raises I18n::MissingTranslationData exception when no translation was found" do
-    assert_raise(I18n::MissingTranslationData) { I18n.t(:faa, :locale => :en, :raise => true) }
-    assert_raise(I18n::MissingTranslationData) { I18n.t(:faa, :locale => :de, :raise => true) }
+    assert_raises(I18n::MissingTranslationData) { I18n.t(:faa, :locale => :en, :raise => true) }
+    assert_raises(I18n::MissingTranslationData) { I18n.t(:faa, :locale => :de, :raise => true) }
   end
 
   test "should ensure that default is not splitted on new line char" do

--- a/test/backend/interpolation_compiler_test.rb
+++ b/test/backend/interpolation_compiler_test.rb
@@ -78,7 +78,7 @@ class InterpolationCompilerTest < I18n::TestCase
   end
 
   def test_raises_exception_when_argument_is_missing
-    assert_raise(I18n::MissingInterpolationArgument) do
+    assert_raises(I18n::MissingInterpolationArgument) do
       compile_and_interpolate('%{first} %{last}', :first => 'first')
     end
   end

--- a/test/backend/key_value_test.rb
+++ b/test/backend/key_value_test.rb
@@ -44,7 +44,7 @@ class I18nBackendKeyValueTest < I18n::TestCase
 
   test "store_translations does not handle subtrees if desired" do
     setup_backend!(false)
-    assert_raise I18n::MissingTranslationData do
+    assert_raises I18n::MissingTranslationData do
       I18n.t("foo", :raise => true)
     end
   end
@@ -65,7 +65,7 @@ class I18nBackendKeyValueTest < I18n::TestCase
   test "subtrees enabled: given incomplete pluralization data it raises I18n::InvalidPluralizationData" do
     setup_backend!
     store_translations(:en, :bar => { :one => "One" })
-    assert_raise(I18n::InvalidPluralizationData) { I18n.t(:bar, :count => 2) }
+    assert_raises(I18n::InvalidPluralizationData) { I18n.t(:bar, :count => 2) }
   end
 
   test "subtrees disabled: given incomplete pluralization data it returns an error message" do

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -45,7 +45,7 @@ class I18nBackendSimpleTest < I18n::TestCase
 
   # loading translations
   test "simple load_translations: given an unknown file type it raises I18n::UnknownFileType" do
-    assert_raise(I18n::UnknownFileType) { I18n.backend.load_translations("#{locales_dir}/en.xml") }
+    assert_raises(I18n::UnknownFileType) { I18n.backend.load_translations("#{locales_dir}/en.xml") }
   end
 
   test "simple load_translations: given a YAML file name with yaml extension does not raise anything" do

--- a/test/backend/transliterator_test.rb
+++ b/test/backend/transliterator_test.rb
@@ -74,7 +74,7 @@ class I18nBackendTransliterator < I18n::TestCase
   test "default transliterator fails with custom rules with uncomposed input" do
     char = [117, 776].pack("U*") # "ü" as ASCII "u" plus COMBINING DIAERESIS
     transliterator = I18n::Backend::Transliterator.get(@hash)
-    assert_not_equal "ue", transliterator.transliterate(char)
+    refute_equal "ue", transliterator.transliterate(char)
   end
 
   test "DEFAULT_APPROXIMATIONS is frozen to prevent concurrency issues" do

--- a/test/backend/transliterator_test.rb
+++ b/test/backend/transliterator_test.rb
@@ -22,7 +22,7 @@ class I18nBackendTransliterator < I18n::TestCase
 
   test "transliteration rule must be a proc or hash" do
     store_translations(:xx, :i18n => {:transliterate => {:rule => ""}})
-    assert_raise I18n::ArgumentError do
+    assert_raises I18n::ArgumentError do
       I18n.backend.transliterate(:xx, "ü")
     end
   end
@@ -57,7 +57,7 @@ class I18nBackendTransliterator < I18n::TestCase
   end
 
   test "default transliterator raises errors for invalid UTF-8" do
-    assert_raise ArgumentError do
+    assert_raises ArgumentError do
       @transliterator.transliterate("a\x92b")
     end
   end

--- a/test/i18n/exceptions_test.rb
+++ b/test/i18n/exceptions_test.rb
@@ -49,7 +49,7 @@ class I18nExceptionsTest < I18n::TestCase
   end
 
   test "MissingInterpolationArgument stores key and string" do
-    assert_raise(I18n::MissingInterpolationArgument) { force_missing_interpolation_argument }
+    assert_raises(I18n::MissingInterpolationArgument) { force_missing_interpolation_argument }
     force_missing_interpolation_argument do |exception|
       assert_equal :bar, exception.key
       assert_equal "%{bar}", exception.string

--- a/test/i18n/interpolate_test.rb
+++ b/test/i18n/interpolate_test.rb
@@ -32,12 +32,12 @@ class I18nInterpolateTest < I18n::TestCase
     assert_equal "  1", I18n.interpolate("%<num>3.0f", :num => 1.0)
     assert_equal "100.00", I18n.interpolate("%<num>2.2f", :num => 100.0)
     assert_equal "0x64", I18n.interpolate("%<num>#x", :num => 100.0)
-    assert_raise(ArgumentError) { I18n.interpolate("%<num>,d", :num => 100) }
-    assert_raise(ArgumentError) { I18n.interpolate("%<num>/d", :num => 100) }
+    assert_raises(ArgumentError) { I18n.interpolate("%<num>,d", :num => 100) }
+    assert_raises(ArgumentError) { I18n.interpolate("%<num>/d", :num => 100) }
   end
 
   test "String interpolation raises an I18n::MissingInterpolationArgument when the string has extra placeholders" do
-    assert_raise(I18n::MissingInterpolationArgument, "key not found") do
+    assert_raises(I18n::MissingInterpolationArgument, "key not found") do
       I18n.interpolate("%{first} %{last}", :first => 'Masao')
     end
   end

--- a/test/i18n/load_path_test.rb
+++ b/test/i18n/load_path_test.rb
@@ -14,14 +14,14 @@ class I18nLoadPathTest < I18n::TestCase
   end
 
   test "loading an empty yml file raises an InvalidLocaleData exception" do
-    assert_raise I18n::InvalidLocaleData do
+    assert_raises I18n::InvalidLocaleData do
       I18n.load_path = [[locales_dir + '/invalid/empty.yml']]
       I18n.t(:'foo.bar', :default => "baz")
     end
   end
 
   test "loading an invalid yml file raises an InvalidLocaleData exception" do
-    assert_raise I18n::InvalidLocaleData do
+    assert_raises I18n::InvalidLocaleData do
       I18n.load_path = [[locales_dir + '/invalid/syntax.yml']]
       I18n.t(:'foo.bar', :default => "baz")
     end

--- a/test/i18n/middleware_test.rb
+++ b/test/i18n/middleware_test.rb
@@ -13,7 +13,7 @@ class I18nMiddlewareTest < I18n::TestCase
     @middleware.call({})
 
     updated_i18n_config_object_id = Thread.current[:i18n_config].object_id
-    assert_not_equal updated_i18n_config_object_id, old_i18n_config_object_id
+    refute_equal updated_i18n_config_object_id, old_i18n_config_object_id
   end
 
   test "succesfully resets i18n locale to default locale by defining new config" do

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -40,13 +40,13 @@ class I18nTest < I18n::TestCase
   end
 
   test "default_locale= doesn't ignore junk" do
-    assert_raise(NoMethodError) { I18n.default_locale = Class }
+    assert_raises(NoMethodError) { I18n.default_locale = Class }
   end
 
   test "raises an I18n::InvalidLocale exception when setting an unavailable default locale" do
     begin
       I18n.config.enforce_available_locales = true
-      assert_raise(I18n::InvalidLocale) { I18n.default_locale = :klingon }
+      assert_raises(I18n::InvalidLocale) { I18n.default_locale = :klingon }
     ensure
       I18n.config.enforce_available_locales = false
     end
@@ -64,13 +64,13 @@ class I18nTest < I18n::TestCase
   end
 
   test "locale= doesn't ignore junk" do
-    assert_raise(NoMethodError) { I18n.locale = Class }
+    assert_raises(NoMethodError) { I18n.locale = Class }
   end
 
   test "raises an I18n::InvalidLocale exception when setting an unavailable locale" do
     begin
       I18n.config.enforce_available_locales = true
-      assert_raise(I18n::InvalidLocale) { I18n.locale = :klingon }
+      assert_raises(I18n::InvalidLocale) { I18n.locale = :klingon }
     ensure
       I18n.config.enforce_available_locales = false
     end
@@ -213,15 +213,15 @@ class I18nTest < I18n::TestCase
   end
 
   test "translate given an empty string as a key raises an I18n::ArgumentError" do
-    assert_raise(I18n::ArgumentError) { I18n.t("") }
+    assert_raises(I18n::ArgumentError) { I18n.t("") }
   end
 
   test "translate given an empty symbol as a key raises an I18n::ArgumentError" do
-    assert_raise(I18n::ArgumentError) { I18n.t(:"") }
+    assert_raises(I18n::ArgumentError) { I18n.t(:"") }
   end
 
   test "translate given an array with empty string as a key raises an I18n::ArgumentError" do
-    assert_raise(I18n::ArgumentError) { I18n.t(["", :foo]) }
+    assert_raises(I18n::ArgumentError) { I18n.t(["", :foo]) }
   end
 
   test "translate given an empty array as a key returns empty array" do
@@ -235,7 +235,7 @@ class I18nTest < I18n::TestCase
   test "translate given an unavailable locale rases an I18n::InvalidLocale" do
     begin
       I18n.config.enforce_available_locales = true
-      assert_raise(I18n::InvalidLocale) { I18n.t(:foo, :locale => 'klingon') }
+      assert_raises(I18n::InvalidLocale) { I18n.t(:foo, :locale => 'klingon') }
     ensure
       I18n.config.enforce_available_locales = false
     end
@@ -251,7 +251,7 @@ class I18nTest < I18n::TestCase
 
   test "translate raises Disabled if locale is false" do
     I18n.with_locale(false) do
-      assert_raise I18n::Disabled do
+      assert_raises I18n::Disabled do
         I18n.t('foo')
       end
 
@@ -262,7 +262,7 @@ class I18nTest < I18n::TestCase
   test "available_locales can be replaced at runtime" do
     begin
       I18n.config.enforce_available_locales = true
-      assert_raise(I18n::InvalidLocale) { I18n.t(:foo, :locale => 'klingon') }
+      assert_raises(I18n::InvalidLocale) { I18n.t(:foo, :locale => 'klingon') }
       old_locales, I18n.config.available_locales = I18n.config.available_locales, [:klingon]
       I18n.t(:foo, :locale => 'klingon')
     ensure
@@ -302,7 +302,7 @@ class I18nTest < I18n::TestCase
 
   test "exists? raises Disabled if locale is false" do
     I18n.with_locale(false) do
-      assert_raise I18n::Disabled do
+      assert_raises I18n::Disabled do
         I18n.exists?(:bogus)
       end
 
@@ -311,7 +311,7 @@ class I18nTest < I18n::TestCase
   end
 
   test "localize given nil raises an I18n::ArgumentError" do
-    assert_raise(I18n::ArgumentError) { I18n.l nil }
+    assert_raises(I18n::ArgumentError) { I18n.l nil }
   end
 
   test "localize given nil and default returns default" do
@@ -319,13 +319,13 @@ class I18nTest < I18n::TestCase
   end
 
   test "localize given an Object raises an I18n::ArgumentError" do
-    assert_raise(I18n::ArgumentError) { I18n.l Object.new }
+    assert_raises(I18n::ArgumentError) { I18n.l Object.new }
   end
 
   test "localize given an unavailable locale rases an I18n::InvalidLocale" do
     begin
       I18n.config.enforce_available_locales = true
-      assert_raise(I18n::InvalidLocale) { I18n.l(Time.now, :locale => 'klingon') }
+      assert_raises(I18n::InvalidLocale) { I18n.l(Time.now, :locale => 'klingon') }
     ensure
       I18n.config.enforce_available_locales = false
     end
@@ -333,7 +333,7 @@ class I18nTest < I18n::TestCase
 
   test "localize raises Disabled if locale is false" do
     I18n.with_locale(false) do
-      assert_raise I18n::Disabled do
+      assert_raises I18n::Disabled do
         I18n.l(Time.now)
       end
     end
@@ -375,14 +375,14 @@ class I18nTest < I18n::TestCase
   end
 
   test "I18n.with_locale resets the locale in case of errors" do
-    assert_raise(I18n::ArgumentError) { I18n.with_locale(:pl) { raise I18n::ArgumentError } }
+    assert_raises(I18n::ArgumentError) { I18n.with_locale(:pl) { raise I18n::ArgumentError } }
     assert_equal I18n.default_locale, I18n.locale
   end
 
   test "I18n.translitarate handles I18n::ArgumentError exception" do
     I18n::Backend::Transliterator.stubs(:get).raises(I18n::ArgumentError)
     I18n.exception_handler.expects(:call).raises(I18n::ArgumentError)
-    assert_raise(I18n::ArgumentError) {
+    assert_raises(I18n::ArgumentError) {
       I18n.transliterate("ąćó")
     }
   end
@@ -390,7 +390,7 @@ class I18nTest < I18n::TestCase
   test "I18n.translitarate raises I18n::ArgumentError exception" do
     I18n::Backend::Transliterator.stubs(:get).raises(I18n::ArgumentError)
     I18n.exception_handler.expects(:call).never
-    assert_raise(I18n::ArgumentError) {
+    assert_raises(I18n::ArgumentError) {
       I18n.transliterate("ąćó", :raise => true)
     }
   end
@@ -398,7 +398,7 @@ class I18nTest < I18n::TestCase
   test "transliterate given an unavailable locale rases an I18n::InvalidLocale" do
     begin
       I18n.config.enforce_available_locales = true
-      assert_raise(I18n::InvalidLocale) { I18n.transliterate('string', :locale => 'klingon') }
+      assert_raises(I18n::InvalidLocale) { I18n.transliterate('string', :locale => 'klingon') }
     ensure
       I18n.config.enforce_available_locales = false
     end
@@ -425,7 +425,7 @@ class I18nTest < I18n::TestCase
   test "I18n.enforce_available_locales! raises an I18n::InvalidLocale when the passed locale is unavailable" do
     begin
       I18n.config.enforce_available_locales = true
-      assert_raise(I18n::InvalidLocale) { I18n.enforce_available_locales!(:klingon) }
+      assert_raises(I18n::InvalidLocale) { I18n.enforce_available_locales!(:klingon) }
     ensure
       I18n.config.enforce_available_locales = false
     end
@@ -462,13 +462,13 @@ class I18nTest < I18n::TestCase
 
       I18n.enforce_available_locales = true
 
-      assert_raise(I18n::InvalidLocale) { I18n.default_locale = :de }
-      assert_raise(I18n::InvalidLocale) { I18n.locale = :de }
+      assert_raises(I18n::InvalidLocale) { I18n.default_locale = :de }
+      assert_raises(I18n::InvalidLocale) { I18n.locale = :de }
 
       store_translations(:de, :foo => 'Foo in :de')
 
-      assert_raise(I18n::InvalidLocale) { I18n.default_locale = :de }
-      assert_raise(I18n::InvalidLocale) { I18n.locale = :de }
+      assert_raises(I18n::InvalidLocale) { I18n.default_locale = :de }
+      assert_raises(I18n::InvalidLocale) { I18n.locale = :de }
 
       I18n.reload!
 

--- a/test/locale/fallbacks_test.rb
+++ b/test/locale/fallbacks_test.rb
@@ -154,7 +154,7 @@ class I18nFallbacksComputationTest < I18n::TestCase
   # Test I18n::Disabled  is raised correctly when locale is false during fallback
 
   test "with locale equals false" do
-    assert_raise I18n::Disabled do
+    assert_raises I18n::Disabled do
       @fallbacks[false]
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,8 +3,6 @@ TEST_CASE = defined?(Minitest::Test) ? Minitest::Test : MiniTest::Unit::TestCase
 
 # TODO: Remove these aliases and update tests accordingly.
 class TEST_CASE
-  alias :assert_not_equal :refute_equal
-
   def assert_nothing_raised(*args)
     yield
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,6 @@ TEST_CASE = defined?(Minitest::Test) ? Minitest::Test : MiniTest::Unit::TestCase
 
 # TODO: Remove these aliases and update tests accordingly.
 class TEST_CASE
-  alias :assert_raise :assert_raises
   alias :assert_not_equal :refute_equal
 
   def assert_nothing_raised(*args)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,19 +1,14 @@
 require 'minitest/autorun'
-TEST_CASE = defined?(Minitest::Test) ? Minitest::Test : MiniTest::Unit::TestCase
-
-# TODO: Remove these aliases and update tests accordingly.
-class TEST_CASE
-  def assert_nothing_raised(*args)
-    yield
-  end
-end
-
 require 'bundler/setup'
 require 'i18n'
 require 'mocha/setup'
 require 'test_declarative'
 
-class I18n::TestCase < TEST_CASE
+class I18n::TestCase < Minitest::Test
+  def assert_nothing_raised(*args)
+    yield
+  end
+
   def self.key_value?
     defined?(ActiveSupport)
   end


### PR DESCRIPTION
This is following a `TODO` added in c6d95dafa30253c992047e699b26377669979af0, to remove aliases and use Minitest when it's available. These should be 👍 now given the version of Rails, Ruby and Minitest we support.

3 changes:
1. Remove alias for `assert_raise` (use: `assert_raises`)
2. Remove alias for `assert_not_equal`) (use: `refute_equal`)
3. Remove conditional usage of `Minitest::Unit::TestCase` (always use `Minitest::Test`)