### PR TITLE
Resolve `Symbol`s using the original fallback locale

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -23,6 +23,7 @@ module I18n
     exception_handler
     fallback
     fallback_in_progress
+    fallback_original_locale
     format
     object
     raise

--- a/lib/i18n/tests/localization/procs.rb
+++ b/lib/i18n/tests/localization/procs.rb
@@ -74,6 +74,7 @@ module I18n
                 arg.strftime('%a, %d %b %Y')
               when Hash
                 arg.delete(:fallback_in_progress)
+                arg.delete(:fallback_original_locale)
                 arg.inspect
               else
                 arg.inspect

--- a/lib/i18n/tests/procs.rb
+++ b/lib/i18n/tests/procs.rb
@@ -53,7 +53,13 @@ module I18n
 
 
       def self.filter_args(*args)
-        args.map {|arg| arg.delete(:fallback_in_progress) if arg.is_a?(Hash) ; arg }.inspect
+        args.map do |arg|
+          if arg.is_a?(Hash)
+            arg.delete(:fallback_in_progress)
+            arg.delete(:fallback_original_locale)
+          end
+          arg
+        end.inspect
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Proof of concept solution to https://github.com/ruby-i18n/i18n/issues/590

### What approach did you choose and why?

I added a new `fallback_original_locale` reserved option, and make use of it in the new `I18n::Backends::Fallbacks#resolve` method.

Seemed like a reasonable way to deal with it? 🤷 

### What should reviewers focus on?

This changes the behaviour of `resolve` when using the `Fallbacks` backend, when a `Symbol` is resolved.

This is probably a bad idea, since it is probably considered a breaking change?

I'm not sure if there is any documentation describing the "Why?" of the "resolve `Symbol`s" feature. It might be the case that this is exactly the desired behaviour, and therefore this is actually "just a bug fix". cc @svenfuchs, who may have more context?

I mostly threw it together to start a conversation about how we might support this behaviour.

### The impact of these changes

Fixes https://github.com/ruby-i18n/i18n/issues/590