### PR TITLE
Fix lookups of `0` keys

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -397,7 +397,7 @@ module I18n
           keys.delete('')
           keys.map! do |k|
             case k
-            when /\A[-+]?[1-9]\d*\z/ # integer
+            when /\A[-+]?([1-9]\d*|0)\z/ # integer
               k.to_i
             when 'true'
               true

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -19,9 +19,29 @@ class I18nBackendSimpleTest < I18n::TestCase
   end
 
   test "simple backend translate: given integer as a key" do
-    store_translations :en, available: { 1 => "Yes", 2 => "No" }
+    store_translations :en, available: { -1 => "Possibly", 0 => "Maybe", 1 => "Yes", 2 => "No", 3 => "Never"  }
+    assert_equal "Possibly", I18n.t(:available)[-1]
+    assert_equal "Possibly", I18n.t('available.-1')
+    assert_equal "Maybe", I18n.t(:available)[0]
+    assert_equal "Maybe", I18n.t('available.0')
     assert_equal "Yes", I18n.t(:available)[1]
     assert_equal "Yes", I18n.t('available.1')
+    assert_equal "No", I18n.t(:available)[2]
+    assert_equal "No", I18n.t('available.2')
+    assert_equal "Never", I18n.t(:available)[3]
+    assert_equal "Never", I18n.t('available.+3')
+  end
+
+  test 'simple backend translate: given integer with a leading positive/negative sign' do
+    store_translations :en, available: { -1 => "No", 0 => "Maybe", 1 => "Yes" }
+    assert_equal 'No', I18n.t(:available)[-1]
+    assert_equal 'No', I18n.t('available.-1')
+    assert_equal 'Maybe', I18n.t(:available)[+0]
+    assert_equal 'Maybe', I18n.t(:available)[-0]
+    assert_equal 'Maybe', I18n.t('available.-0')
+    assert_equal 'Maybe', I18n.t('available.+0')
+    assert_equal 'Yes', I18n.t(:available)[+1]
+    assert_equal 'Yes', I18n.t('available.+1')
   end
 
   test 'simple backend translate: given integer with a lead zero as a key' do


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #593 

https://github.com/ruby-i18n/i18n/pull/457 introduced a bug where `0` was no longer considered an integer, and so lookups of `0` keys failed.

### What approach did you choose and why?

Fixed the regex to allow `0`, and added more test coverage.

### What should reviewers focus on?

🤷 Alright regex?

### The impact of these changes

Lookups of keys that end in `.0` will work once again.