### PR TITLE
Test on Ruby 3.1 & Rails 7.0x

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -45,10 +45,13 @@ jobs:
           # Ruby 2.6.x is not supported by Rails main
           - ruby_version: 2.6
             gemfile: gemfiles/Gemfile.rails-main
+          # Ruby 2.6.x is not supported by Rails 7.0.x
+          - ruby_version: 2.6
+            gemfile: gemfiles/Gemfile.rails-7.0.x
           # Ruby 2.5.x is not supported by Rails main
           - ruby_version: 2.5
             gemfile: gemfiles/Gemfile.rails-main
-          # Ruby 2.5.x is not supported by Rails 7.0
+          # Ruby 2.5.x is not supported by Rails 7.0.x
           - ruby_version: 2.5
             gemfile: gemfiles/Gemfile.rails-7.0.x
           # Ruby 2.4.x is not supported by Rails main

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,6 +42,9 @@ jobs:
           # Ruby 2.6.x is not supported by Rails main
           - ruby_version: 2.6
             gemfile: gemfiles/Gemfile.rails-main
+          # Ruby 2.6.x is not supported by Rails main
+          - ruby_version: 2.6
+            gemfile: gemfiles/Gemfile.rails-main
           # Ruby 2.5.x is not supported by Rails main
           - ruby_version: 2.5
             gemfile: gemfiles/Gemfile.rails-main
@@ -54,15 +57,18 @@ jobs:
           # Ruby 2.4.x is not supported by Rails 6.0.x
           - ruby_version: 2.4
             gemfile: gemfiles/Gemfile.rails-6.0.x
+          # Ruby 2.4.x is not supported by Rails 7.0.x
+          - ruby_version: 2.4
+            gemfile: gemfiles/Gemfile.rails-7.0.x
           # Ruby 2.3.x is not supported by Rails 6.1.x
           - ruby_version: 2.3
             gemfile: gemfiles/Gemfile.rails-6.1.x
-          # Ruby 2.3.x is not supported by Rails main
-          - ruby_version: 2.3
-            gemfile: gemfiles/Gemfile.rails-main
           # Ruby 2.3.x is not supported by Rails 6.0.x
           - ruby_version: 2.3
             gemfile: gemfiles/Gemfile.rails-6.0.x
+          # Ruby 2.3.x is not supported by Rails main
+          - ruby_version: 2.3
+            gemfile: gemfiles/Gemfile.rails-main
           # JRuby is not supported by Rails main
           - ruby_version: jruby
             gemfile: gemfiles/Gemfile.rails-main

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -66,6 +66,9 @@ jobs:
           # Ruby 2.4.x is not supported by Rails 7.0.x
           - ruby_version: 2.4
             gemfile: gemfiles/Gemfile.rails-7.0.x
+          # Ruby 2.3.x is not supported by Rails 7.0.x
+          - ruby_version: 2.3
+            gemfile: gemfiles/Gemfile.rails-7.0.x
           # Ruby 2.3.x is not supported by Rails 6.1.x
           - ruby_version: 2.3
             gemfile: gemfiles/Gemfile.rails-6.1.x

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -94,6 +94,10 @@ jobs:
           - ruby_version: 2.3
             gemfile: gemfiles/Gemfile.rails-main
 
+          # JRuby is not supported by Rails 7.0.x
+          - ruby_version: jruby
+            gemfile: gemfiles/Gemfile.rails-7.0.x
+
           # JRuby is not supported by Rails main
           - ruby_version: jruby
             gemfile: gemfiles/Gemfile.rails-main

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -50,10 +50,6 @@ jobs:
           - ruby_version: 2.6
             gemfile: gemfiles/Gemfile.rails-main
 
-          # Ruby 2.6.x is not supported by Rails main
-          - ruby_version: 2.6
-            gemfile: gemfiles/Gemfile.rails-main
-
           # Ruby 2.6.x is not supported by Rails 7.0.x
           - ruby_version: 2.6
             gemfile: gemfiles/Gemfile.rails-7.0.x

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,6 +30,10 @@ jobs:
             gemfiles/Gemfile.rails-main,
           ]
         exclude:
+          # Ruby 3.1 is not supported by Rails 5.2.x
+          - ruby_version: 3.1
+            gemfile: gemfiles/Gemfile.rails-5.2.x
+
           # Ruby 3.x is not supported by Rails 5.2.x
           - ruby_version: 3.0
             gemfile: gemfiles/Gemfile.rails-5.2.x

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,12 +17,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: [3.1, "3.0", 2.7, 2.6, 2.5, 2.4, 2.3, jruby]
+        ruby_version: [3.1, "3.0", 2.7, 2.6, jruby]
         gemfile:
           [
             Gemfile,
-            gemfiles/Gemfile.rails-5.0.x,
-            gemfiles/Gemfile.rails-5.1.x,
             gemfiles/Gemfile.rails-5.2.x,
             gemfiles/Gemfile.rails-6.0.x,
             gemfiles/Gemfile.rails-6.1.x,
@@ -38,14 +36,6 @@ jobs:
           - ruby_version: 3.0
             gemfile: gemfiles/Gemfile.rails-5.2.x
 
-          # Ruby 3.x is not supported by Rails 5.1.x
-          - ruby_version: 3.0
-            gemfile: gemfiles/Gemfile.rails-5.1.x
-
-          # Ruby 3.x is not supported by Rails 5.0.x
-          - ruby_version: 3.0
-            gemfile: gemfiles/Gemfile.rails-5.0.x
-
           # Ruby 2.6.x is not supported by Rails main
           - ruby_version: 2.6
             gemfile: gemfiles/Gemfile.rails-main
@@ -53,46 +43,6 @@ jobs:
           # Ruby 2.6.x is not supported by Rails 7.0.x
           - ruby_version: 2.6
             gemfile: gemfiles/Gemfile.rails-7.0.x
-
-          # Ruby 2.5.x is not supported by Rails main
-          - ruby_version: 2.5
-            gemfile: gemfiles/Gemfile.rails-main
-
-          # Ruby 2.5.x is not supported by Rails 7.0.x
-          - ruby_version: 2.5
-            gemfile: gemfiles/Gemfile.rails-7.0.x
-
-          # Ruby 2.4.x is not supported by Rails main
-          - ruby_version: 2.4
-            gemfile: gemfiles/Gemfile.rails-main
-
-          # Ruby 2.4.x is not supported by Rails 6.1.x
-          - ruby_version: 2.4
-            gemfile: gemfiles/Gemfile.rails-6.1.x
-
-          # Ruby 2.4.x is not supported by Rails 6.0.x
-          - ruby_version: 2.4
-            gemfile: gemfiles/Gemfile.rails-6.0.x
-
-          # Ruby 2.4.x is not supported by Rails 7.0.x
-          - ruby_version: 2.4
-            gemfile: gemfiles/Gemfile.rails-7.0.x
-
-          # Ruby 2.3.x is not supported by Rails 7.0.x
-          - ruby_version: 2.3
-            gemfile: gemfiles/Gemfile.rails-7.0.x
-
-          # Ruby 2.3.x is not supported by Rails 6.1.x
-          - ruby_version: 2.3
-            gemfile: gemfiles/Gemfile.rails-6.1.x
-
-          # Ruby 2.3.x is not supported by Rails 6.0.x
-          - ruby_version: 2.3
-            gemfile: gemfiles/Gemfile.rails-6.0.x
-
-          # Ruby 2.3.x is not supported by Rails main
-          - ruby_version: 2.3
-            gemfile: gemfiles/Gemfile.rails-main
 
           # JRuby is not supported by Rails 7.0.x
           - ruby_version: jruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,51 +33,67 @@ jobs:
           # Ruby 3.x is not supported by Rails 5.2.x
           - ruby_version: 3.0
             gemfile: gemfiles/Gemfile.rails-5.2.x
+
           # Ruby 3.x is not supported by Rails 5.1.x
           - ruby_version: 3.0
             gemfile: gemfiles/Gemfile.rails-5.1.x
+
           # Ruby 3.x is not supported by Rails 5.0.x
           - ruby_version: 3.0
             gemfile: gemfiles/Gemfile.rails-5.0.x
+
           # Ruby 2.6.x is not supported by Rails main
           - ruby_version: 2.6
             gemfile: gemfiles/Gemfile.rails-main
+
           # Ruby 2.6.x is not supported by Rails main
           - ruby_version: 2.6
             gemfile: gemfiles/Gemfile.rails-main
+
           # Ruby 2.6.x is not supported by Rails 7.0.x
           - ruby_version: 2.6
             gemfile: gemfiles/Gemfile.rails-7.0.x
+
           # Ruby 2.5.x is not supported by Rails main
           - ruby_version: 2.5
             gemfile: gemfiles/Gemfile.rails-main
+
           # Ruby 2.5.x is not supported by Rails 7.0.x
           - ruby_version: 2.5
             gemfile: gemfiles/Gemfile.rails-7.0.x
+
           # Ruby 2.4.x is not supported by Rails main
           - ruby_version: 2.4
             gemfile: gemfiles/Gemfile.rails-main
+
           # Ruby 2.4.x is not supported by Rails 6.1.x
           - ruby_version: 2.4
             gemfile: gemfiles/Gemfile.rails-6.1.x
+
           # Ruby 2.4.x is not supported by Rails 6.0.x
           - ruby_version: 2.4
             gemfile: gemfiles/Gemfile.rails-6.0.x
+
           # Ruby 2.4.x is not supported by Rails 7.0.x
           - ruby_version: 2.4
             gemfile: gemfiles/Gemfile.rails-7.0.x
+
           # Ruby 2.3.x is not supported by Rails 7.0.x
           - ruby_version: 2.3
             gemfile: gemfiles/Gemfile.rails-7.0.x
+
           # Ruby 2.3.x is not supported by Rails 6.1.x
           - ruby_version: 2.3
             gemfile: gemfiles/Gemfile.rails-6.1.x
+
           # Ruby 2.3.x is not supported by Rails 6.0.x
           - ruby_version: 2.3
             gemfile: gemfiles/Gemfile.rails-6.0.x
+
           # Ruby 2.3.x is not supported by Rails main
           - ruby_version: 2.3
             gemfile: gemfiles/Gemfile.rails-main
+
           # JRuby is not supported by Rails main
           - ruby_version: jruby
             gemfile: gemfiles/Gemfile.rails-main

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["3.0", 2.7, 2.6, 2.5, 2.4, 2.3, jruby]
+        ruby_version: [3.1, "3.0", 2.7, 2.6, 2.5, 2.4, 2.3, jruby]
         gemfile:
           [
             Gemfile,
@@ -26,6 +26,7 @@ jobs:
             gemfiles/Gemfile.rails-5.2.x,
             gemfiles/Gemfile.rails-6.0.x,
             gemfiles/Gemfile.rails-6.1.x,
+            gemfiles/Gemfile.rails-7.0.x,
             gemfiles/Gemfile.rails-main,
           ]
         exclude:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -48,6 +48,9 @@ jobs:
           # Ruby 2.5.x is not supported by Rails main
           - ruby_version: 2.5
             gemfile: gemfiles/Gemfile.rails-main
+          # Ruby 2.5.x is not supported by Rails 7.0
+          - ruby_version: 2.5
+            gemfile: gemfiles/Gemfile.rails-7.0.x
           # Ruby 2.4.x is not supported by Rails main
           - ruby_version: 2.4
             gemfile: gemfiles/Gemfile.rails-main

--- a/gemfiles/Gemfile.rails-7.0.x
+++ b/gemfiles/Gemfile.rails-7.0.x
@@ -1,0 +1,13 @@
+source 'https://rubygems.org'
+
+gemspec :path => '..'
+
+gem 'activesupport', '~> 7.0'
+gem 'mocha', '~> 1.7.0'
+gem 'test_declarative', '0.0.6'
+gem 'rake'
+gem 'minitest', '~> 5.14'
+
+platforms :mri do
+  gem 'oj'
+end


### PR DESCRIPTION
To make it easier to maintain this library, I am choosing to support the last 4 Ruby and 4 Rails versions. This is inline with the Rails maintenance policy, which also supports Rails versions from 5.2 and up.