### PR TITLE
fix ReDoS

### DIFF
--- a/lib/i18n/interpolate/ruby.rb
+++ b/lib/i18n/interpolate/ruby.rb
@@ -5,7 +5,7 @@ module I18n
   DEFAULT_INTERPOLATION_PATTERNS = [
     /%%/,
     /%\{([\w|]+)\}/,                            # matches placeholders like "%{foo} or %{foo|word}"
-    /%<(\w+)>(.*?\d*\.?\d*[bBdiouxXeEfgGcps])/  # matches placeholders like "%<foo>.d"
+    /%<(\w+)>([^\d]*?\d*\.?\d*[bBdiouxXeEfgGcps])/  # matches placeholders like "%<foo>.d"
   ].freeze
   INTERPOLATION_PATTERN = Regexp.union(DEFAULT_INTERPOLATION_PATTERNS)
   deprecate_constant :INTERPOLATION_PATTERN


### PR DESCRIPTION
In the process of investigating Rails regular expressions using [Regexploit](https://github.com/doyensec/regexploit), I discovered that i18n sometimes had ReDoS problems.
ReDoS seems to occur when there is a code like below.

```ruby
I18n.interpolate('%<0>' + '0' * 3456, :num => 1)
```

The problem occurs when there is a translation file like the one below, but it seems that there are few cases where an attacker can inject on it.

```yaml
en:
  test: "%<0>000..." # 0 * 3456
```  

#### Results of Regexploit

```
(?-mix:%%)|(?-mix:%\{([\w|]+)\})|(?-mix:%<(\w+)>(.*?\d*\.?\d*[bBdiouxXeEfgGcps]))
Pattern: (?-mix:%%)|(?-mix:%\{([\w|]+)\})|(?-mix:%<(\w+)>(.*?\d*\.?\d*[bBdiouxXeEfgGcps]))
---
Redos(starriness=3, prefix_sequence=SEQ{ [25:%] [3c:<] [WORD]{1+} [3e:>] }, redos_sequence=SEQ{ .{0+} [DIGIT]{0+} [2e:.]{0,1} [DIGIT]{0+} [B,E,G,i,o,p,s,u,X,x,[b-g]] }, repeated_character=[DIGIT], killer=None)
Worst-case complexity: 3 ⭐⭐⭐ (cubic)
Repeated character: [DIGIT]
Example: '%<0>' + '0' * 3456


(?-mix:%%)|(?-mix:%\{([\w|]+)\})|(?-mix:%<(\w+)>([^\d]*?\d*\.?\d*[bBdiouxXeEfgGcps]))
No ReDoS found.
```