### PR TITLE
Conditionally assert load_json returns symbolized data

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -255,7 +255,7 @@ module I18n
         def load_json(filename)
           begin
             # Use #load_file as a proxy for a version of JSON where symbolize_names and freeze are supported.
-            if JSON.respond_to?(:load_file)
+            if ::JSON.respond_to?(:load_file)
               [::JSON.load_file(filename, symbolize_names: true, freeze: true), true]
             else
               [::JSON.parse(File.read(filename)), false]

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -97,10 +97,12 @@ class I18nBackendSimpleTest < I18n::TestCase
 
   test "simple load_json: loads data from a JSON file" do
     data, _ = I18n.backend.send(:load_json, "#{locales_dir}/en.json")
-    assert_equal({ :en => { :foo => { :bar => 'baz' } } }, data)
 
     if JSON.respond_to?(:load_file)
+      assert_equal({ :en => { :foo => { :bar => 'baz' } } }, data)
       assert_predicate data.dig(:en, :foo, :bar), :frozen?
+    else
+      assert_equal({ 'en' => { 'foo' => { 'bar' => 'baz' } } }, data)
     end
   end
 


### PR DESCRIPTION
A bad rebase removed this diff from #587. This should fix the failing build on master, we now conditionally assert that data is symbolized.