### PR TITLE
Revert "Fix missing requires of i18n/core_ext/hash"

### DIFF
--- a/lib/i18n/backend/chain.rb
+++ b/lib/i18n/backend/chain.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'i18n/core_ext/hash'
-
 module I18n
   module Backend
     # Backend that chains multiple other backends and checks each of them when

--- a/lib/i18n/backend/gettext.rb
+++ b/lib/i18n/backend/gettext.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'i18n/core_ext/hash'
 require 'i18n/gettext'
 require 'i18n/gettext/po_parser'
 

--- a/test/backend/chain_test.rb
+++ b/test/backend/chain_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'i18n/backend/chain'
 
 class I18nBackendChainTest < I18n::TestCase
   def setup

--- a/test/gettext/backend_test.rb
+++ b/test/gettext/backend_test.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 require 'test_helper'
-require 'i18n/backend/gettext'
 
 class I18nGettextBackendTest < I18n::TestCase
   include I18n::Gettext::Helpers


### PR DESCRIPTION
Reverts ruby-i18n/i18n#574

This was breaking the master build.