### PR TITLE
Remove warning: assigned but unused variable

### DIFF
--- a/test/backend/cache_test.rb
+++ b/test/backend/cache_test.rb
@@ -62,7 +62,7 @@ class I18nBackendCacheTest < I18n::TestCase
     I18n.t(:missing, :scope => :foo, :extra => true)
     assert_equal 1, I18n.cache_store.instance_variable_get(:@data).size
 
-    cache_key, entry = I18n.cache_store.instance_variable_get(:@data).first
+    _, entry = I18n.cache_store.instance_variable_get(:@data).first
     assert_equal({ scope: :foo }, entry.value.options)
   end
 


### PR DESCRIPTION
This PR suppresses the following warning.
```
/home/runner/work/i18n/i18n/test/backend/cache_test.rb:65: warning: assigned but unused variable - cache_key
```