### PR TITLE
LazyLoadable Backend

### DIFF
--- a/lib/i18n/backend.rb
+++ b/lib/i18n/backend.rb
@@ -3,7 +3,6 @@
 module I18n
   module Backend
     autoload :Base,                  'i18n/backend/base'
-    autoload :InterpolationCompiler, 'i18n/backend/interpolation_compiler'
     autoload :Cache,                 'i18n/backend/cache'
     autoload :CacheFile,             'i18n/backend/cache_file'
     autoload :Cascade,               'i18n/backend/cascade'
@@ -11,6 +10,7 @@ module I18n
     autoload :Fallbacks,             'i18n/backend/fallbacks'
     autoload :Flatten,               'i18n/backend/flatten'
     autoload :Gettext,               'i18n/backend/gettext'
+    autoload :InterpolationCompiler, 'i18n/backend/interpolation_compiler'
     autoload :KeyValue,              'i18n/backend/key_value'
     autoload :Memoize,               'i18n/backend/memoize'
     autoload :Metadata,              'i18n/backend/metadata'

--- a/lib/i18n/backend.rb
+++ b/lib/i18n/backend.rb
@@ -12,6 +12,7 @@ module I18n
     autoload :Gettext,               'i18n/backend/gettext'
     autoload :InterpolationCompiler, 'i18n/backend/interpolation_compiler'
     autoload :KeyValue,              'i18n/backend/key_value'
+    autoload :LazyLoadable,          'i18n/backend/lazy_loadable'
     autoload :Memoize,               'i18n/backend/memoize'
     autoload :Metadata,              'i18n/backend/metadata'
     autoload :Pluralization,         'i18n/backend/pluralization'

--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -13,7 +13,10 @@ module I18n
       # for details.
       def load_translations(*filenames)
         filenames = I18n.load_path if filenames.empty?
-        filenames.flatten.each { |filename| load_file(filename) }
+        filenames.flatten.each do |filename|
+          loaded_translations = load_file(filename)
+          yield filename, loaded_translations if block_given?
+        end
       end
 
       # This method receives a locale, a data hash and options for storing translations.
@@ -226,6 +229,8 @@ module I18n
             raise InvalidLocaleData.new(filename, 'expects it to return a hash, but does not')
           end
           data.each { |locale, d| store_translations(locale, d || {}, skip_symbolize_keys: keys_symbolized) }
+
+          data
         end
 
         # Loads a plain Ruby translations file. eval'ing the file must yield

--- a/lib/i18n/backend/lazy_loadable.rb
+++ b/lib/i18n/backend/lazy_loadable.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+module I18n
+  module Backend
+    # Backend that lazy loads translations based on the current locale. This
+    # implementation avoids loading all translations up front. Instead, it only
+    # loads the translations that belong to the current locale. This offers a
+    # performance incentive in local development and test environments for
+    # applications with many translations for many different locales. It's
+    # particularly useful when the application only refers to a single locales'
+    # translations at a time (ex. A Rails workload).  The implementation
+    # identifies which translation files from the load path belong to the
+    # current locale by pattern matching against their path name.
+    #
+    # Specifically, a translation file is considered to belong to a locale if:
+    # a) the filename is in the I18n load path
+    # b) the filename ends in a supported extension (ie. .yml, .json, .po, .rb)
+    # c) the filename starts with the locale identifier
+    # d) the locale identifier and optional proceeding text is separated by an underscore, ie. "_".
+    #
+    # Examples:
+    # Valid files that will be selected by this backend:
+    #
+    # "files/locales/en_translation.yml" (Selected for locale "en")
+    # "files/locales/fr.po"  (Selected for locale "fr")
+    #
+    # Invalid files that won't be selected by this backend:
+    #
+    # "files/locales/translation-file"
+    # "files/locales/en-translation.unsupported"
+    # "files/locales/french/translation.yml"
+    # "files/locales/fr/translation.yml"
+    #
+    # The implementation uses this assumption to defer the loading of
+    # translation files until the current locale actually requires them.
+    #
+    # The backend has two working modes: lazy_load and eager_load.
+    #
+    # Note: This backend should only be enabled in test environments!
+    # When the mode is set to false, the backend behaves exactly like the
+    # Simple backend, with an additional check that the paths being loaded
+    # abide by the format. If paths can't be matched to the format, an error is raised.
+    #
+    # You can configure lazy loaded backends through the initializer or backends
+    # accessor:
+    #
+    #   # In test environments
+    #
+    #   I18n.backend = I18n::Backend::LazyLoadable.new(lazy_load: true)
+    #
+    #   # In other environments, such as production and CI
+    #
+    #   I18n.backend = I18n::Backend::LazyLoadable.new(lazy_load: false) # default
+    #
+    class LocaleExtractor
+      class << self
+        def locale_from_path(path)
+          name = File.basename(path, ".*")
+          locale = name.split("_").first
+          locale.to_sym unless locale.nil?
+        end
+      end
+    end
+
+    class LazyLoadable < Simple
+      def initialize(lazy_load: false)
+        @lazy_load = lazy_load
+      end
+
+      # Returns whether the current locale is initialized.
+      def initialized?
+        if lazy_load?
+          initialized_locales[I18n.locale]
+        else
+          super
+        end
+      end
+
+      # Clean up translations and uninitialize all locales.
+      def reload!
+        if lazy_load?
+          @initialized_locales = nil
+          @translations = nil
+        else
+          super
+        end
+      end
+
+      # Eager loading is not supported in the lazy context.
+      def eager_load!
+        if lazy_load?
+          raise UnsupportedMethod.new(__method__, self.class, "Cannot eager load translations because backend was configured with lazy_load: true.")
+        else
+          super
+        end
+      end
+
+      # Parse the load path and extract all locales.
+      def available_locales
+        if lazy_load?
+          I18n.load_path.map { |path| LocaleExtractor.locale_from_path(path) }
+        else
+          super
+        end
+      end
+
+      def lookup(locale, key, scope = [], options = EMPTY_HASH)
+        if lazy_load?
+          I18n.with_locale(locale) do
+            super
+          end
+        else
+          super
+        end
+      end
+
+      protected
+
+
+      # Load translations from files that belong to the current locale.
+      def init_translations
+        file_errors = if lazy_load?
+          initialized_locales[I18n.locale] = true
+          load_translations_and_collect_file_errors(filenames_for_current_locale)
+        else
+          @initialized = true
+          load_translations_and_collect_file_errors(I18n.load_path)
+        end
+
+        raise InvalidFilenames.new(file_errors) unless file_errors.empty?
+      end
+
+      def initialized_locales
+        @initialized_locales ||= Hash.new(false)
+      end
+
+      private
+
+      def lazy_load?
+        @lazy_load
+      end
+
+      class FilenameIncorrect < StandardError
+        def initialize(file, expected_locale, unexpected_locales)
+          super "#{file} can only load translations for \"#{expected_locale}\". Found translations for: #{unexpected_locales}."
+        end
+      end
+
+      # Loads each file supplied and asserts that the file only loads
+      # translations as expected by the name. The method returns a list of
+      # errors corresponding to offending files.
+      def load_translations_and_collect_file_errors(files)
+        errors = []
+
+        load_translations(files) do |file, loaded_translations|
+          assert_file_named_correctly!(file, loaded_translations)
+        rescue FilenameIncorrect => e
+          errors << e
+        end
+
+        errors
+      end
+
+      # Select all files from I18n load path that belong to current locale.
+      # These files must start with the locale identifier (ie. "en", "pt-BR"),
+      # followed by an "_" demarcation to separate proceeding text.
+      def filenames_for_current_locale
+        I18n.load_path.flatten.select do |path|
+          LocaleExtractor.locale_from_path(path) == I18n.locale
+        end
+      end
+
+      # Checks if a filename is named in correspondence to the translations it loaded.
+      # The locale extracted from the path must be the single locale loaded in the translations.
+      def assert_file_named_correctly!(file, translations)
+        loaded_locales = translations.keys.map(&:to_sym)
+        expected_locale = LocaleExtractor.locale_from_path(file)
+        unexpected_locales = loaded_locales.reject { |locale| locale == expected_locale }
+
+        raise FilenameIncorrect.new(file, expected_locale, unexpected_locales) unless unexpected_locales.empty?
+      end
+    end
+  end
+end

--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -110,4 +110,38 @@ module I18n
       super "can not load translations from #{filename}, the file type #{type} is not known"
     end
   end
+
+  class UnsupportedMethod < ArgumentError
+    attr_reader :method, :backend_klass, :msg
+    def initialize(method, backend_klass, msg)
+      @method = method
+      @backend_klass = backend_klass
+      @msg = msg
+      super "#{backend_klass} does not support the ##{method} method. #{msg}"
+    end
+  end
+
+  class InvalidFilenames < ArgumentError
+    NUMBER_OF_ERRORS_SHOWN = 20
+    def initialize(file_errors)
+      super <<~MSG
+        Found #{file_errors.count} error(s).
+        The first #{[file_errors.count, NUMBER_OF_ERRORS_SHOWN].min} error(s):
+        #{file_errors.map(&:message).first(NUMBER_OF_ERRORS_SHOWN).join("\n")}
+
+        To use the LazyLoadable backend:
+        1. Filenames must start with the locale.
+        2. An underscore must separate the locale with any optional text that follows.
+        3. The file must only contain translation data for the single locale.
+
+        Example:
+        "/config/locales/fr.yml" which contains:
+        ```yml
+          fr:
+            dog:
+              chien
+        ```
+      MSG
+    end
+  end
 end

--- a/lib/i18n/tests/basics.rb
+++ b/lib/i18n/tests/basics.rb
@@ -5,12 +5,11 @@ module I18n
         I18n.available_locales = nil
       end
 
-      test "available_locales returns the locales stored to the backend by default" do
+      test "available_locales returns the available_locales produced by the backend, by default" do
         I18n.backend.store_translations('de', :foo => 'bar')
         I18n.backend.store_translations('en', :foo => 'foo')
 
-        assert I18n.available_locales.include?(:de)
-        assert I18n.available_locales.include?(:en)
+        assert_equal I18n.available_locales, I18n.backend.available_locales
       end
 
       test "available_locales can be set to something else independently from the actual locale data" do
@@ -24,8 +23,7 @@ module I18n
         assert_equal [:foo, :bar], I18n.available_locales
 
         I18n.available_locales = nil
-        assert I18n.available_locales.include?(:de)
-        assert I18n.available_locales.include?(:en)
+        assert_equal I18n.available_locales, I18n.backend.available_locales
       end
 
       test "available_locales memoizes when set explicitely" do

--- a/test/api/lazy_loadable_test.rb
+++ b/test/api/lazy_loadable_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class I18nLazyLoadableBackendApiTest < I18n::TestCase
+  def setup
+    I18n.backend = I18n::Backend::LazyLoadable.new
+    super
+  end
+
+  include I18n::Tests::Basics
+  include I18n::Tests::Defaults
+  include I18n::Tests::Interpolation
+  include I18n::Tests::Link
+  include I18n::Tests::Lookup
+  include I18n::Tests::Pluralization
+  include I18n::Tests::Procs
+  include I18n::Tests::Localization::Date
+  include I18n::Tests::Localization::DateTime
+  include I18n::Tests::Localization::Time
+  include I18n::Tests::Localization::Procs
+
+  test "make sure we use the LazyLoadable backend" do
+    assert_equal I18n::Backend::LazyLoadable, I18n.backend.class
+  end
+end

--- a/test/backend/lazy_loadable_test.rb
+++ b/test/backend/lazy_loadable_test.rb
@@ -1,0 +1,223 @@
+require 'test_helper'
+
+class I18nBackendLazyLoadableTest < I18n::TestCase
+  def setup
+    super
+
+    @lazy_mode_backend = I18n::Backend::LazyLoadable.new(lazy_load: true)
+    @eager_mode_backend = I18n::Backend::LazyLoadable.new(lazy_load: false)
+
+    I18n.load_path = [File.join(locales_dir, '/en.yml'), File.join(locales_dir,  '/fr.yml')]
+  end
+
+  test "lazy mode: only loads translations for current locale" do
+    with_lazy_mode do
+      @backend.reload!
+
+      assert_nil translations
+
+      I18n.with_locale(:en) { I18n.t("foo.bar") }
+      assert_equal({ en: { foo: { bar: "baz" }}}, translations)
+    end
+  end
+
+  test "lazy mode: merges translations for current locale with translations already existing in memory" do
+    with_lazy_mode do
+      @backend.reload!
+
+      I18n.with_locale(:en) { I18n.t("foo.bar") }
+      assert_equal({ en: { foo: { bar: "baz" }}}, translations)
+
+      I18n.with_locale(:fr) { I18n.t("animal.dog") }
+      assert_equal({ en: { foo: { bar: "baz" } }, fr: { animal: { dog: "chien" } } }, translations)
+    end
+  end
+
+  test "lazy mode: #initialized? responds based on whether current locale is initialized" do
+    with_lazy_mode do
+      @backend.reload!
+
+      I18n.with_locale(:en) do
+        refute_predicate @backend, :initialized?
+        I18n.t("foo.bar")
+        assert_predicate @backend, :initialized?
+      end
+
+      I18n.with_locale(:fr) do
+        refute_predicate @backend, :initialized?
+      end
+    end
+  end
+
+  test "lazy mode: reload! uninitializes all locales" do
+    with_lazy_mode do
+      I18n.with_locale(:en) { I18n.t("foo.bar") }
+      I18n.with_locale(:fr) { I18n.t("animal.dog") }
+
+      @backend.reload!
+
+      I18n.with_locale(:en) do
+        refute_predicate @backend, :initialized?
+      end
+
+      I18n.with_locale(:fr) do
+        refute_predicate @backend, :initialized?
+      end
+    end
+  end
+
+  test "lazy mode: eager_load! raises UnsupportedMethod exception" do
+    with_lazy_mode do
+      exception = assert_raises(I18n::UnsupportedMethod) { @backend.eager_load! }
+      expected_msg = "I18n::Backend::LazyLoadable does not support the #eager_load! method. Cannot eager load translations because backend was configured with lazy_load: true." 
+      assert_equal expected_msg, exception.message
+    end
+  end
+
+  test "lazy mode: loads translations from files that start with current locale identifier" do
+    with_lazy_mode do
+      file_contents = { en: { alice: "bob" } }.to_yaml
+
+      invalid_files = [
+        { filename: ['translation', '.yml'] },                # No locale identifier
+        { filename: ['translation', '.unsupported'] },        # No locale identifier and unsupported extension
+      ]
+
+      invalid_files.each do |file|
+        with_translation_file_in_load_path(file[:filename], file[:dir], file_contents) do
+          I18n.with_locale(:en) { I18n.t("foo.bar") }
+          assert_equal({ en: { foo: { bar: "baz" }}}, translations)
+        end
+      end
+
+      valid_files = [
+        { filename: ['en_translation', '.yml'] },         # Contains locale identifier with correct demarcation, and supported extension
+        { filename: ['en_', '.yml'] },                    # Path component matches locale identifier exactly
+      ]
+
+      valid_files.each do |file|
+        with_translation_file_in_load_path(file[:filename], file[:dir], file_contents) do
+          I18n.with_locale(:en) { I18n.t("foo.bar") }
+          assert_equal({ en: { foo: { bar: "baz" }, alice: "bob" }}, translations)
+        end
+      end
+    end
+  end
+
+  test "lazy mode: files with unsupported extensions raise UnknownFileType error" do
+    with_lazy_mode do
+      file_contents = { en: { alice: "bob" } }.to_yaml
+      filename =  ['en_translation', '.unsupported']     # Correct locale identifier, but unsupported extension
+
+      with_translation_file_in_load_path(filename, nil, file_contents) do
+        assert_raises(I18n::UnknownFileType) { I18n.t("foo.bar") }
+      end
+    end
+  end
+
+  test "lazy mode: #available_locales returns all locales available from load path irrespective of current locale" do
+    with_lazy_mode do
+      I18n.with_locale(:en) { assert_equal [:en, :fr], @backend.available_locales }
+      I18n.with_locale(:fr) { assert_equal [:en, :fr], @backend.available_locales }
+    end
+  end
+
+  test "lazy mode: raises error if translations loaded don't correspond to locale extracted from filename" do
+    filename = ["en_", ".yml"]
+    file_contents = { fr: { dog: "chien" } }.to_yaml
+
+    with_lazy_mode do
+      with_translation_file_in_load_path(filename, nil, file_contents) do |file_path|
+        exception = assert_raises(I18n::InvalidFilenames) { I18n.t("foo.bar") }
+
+        expected_message = /#{Regexp.escape(file_path)} can only load translations for "en"\. Found translations for: \[\:fr\]/
+        assert_match expected_message, exception.message
+      end
+    end
+  end
+
+  test "lazy mode: raises error if translations for more than one locale are loaded from a single file" do
+    filename = ["en_", ".yml"]
+    file_contents = { en: { alice: "bob" },  fr: { dog: "chien" }, de: { cat: 'katze' } }.to_yaml
+
+    with_lazy_mode do
+      with_translation_file_in_load_path(filename, nil, file_contents) do |file_path|
+        exception = assert_raises(I18n::InvalidFilenames) { I18n.t("foo.bar") }
+
+        expected_message = /#{Regexp.escape(file_path)} can only load translations for "en"\. Found translations for: \[\:fr\, \:de\]/
+        assert_match expected_message, exception.message
+      end
+    end
+  end
+
+  test "lazy mode: #lookup lazy loads translations for supplied locale" do
+    with_lazy_mode do
+      @backend.reload!
+      assert_nil translations
+
+      I18n.with_locale(:en) do
+        assert_equal "chien", @backend.lookup(:fr, "animal.dog")
+      end
+
+      assert_equal({ fr: { animal: { dog: "chien" } } }, translations)
+    end
+  end
+
+  test "eager mode: load all translations, irrespective of locale" do
+    with_eager_mode do
+      @backend.reload!
+
+      assert_nil translations
+
+      I18n.with_locale(:en) { I18n.t("foo.bar") }
+      assert_equal({ en: { foo: { bar: "baz" } }, fr: { animal: { dog: "chien" } } }, translations)
+    end
+  end
+
+  test "eager mode: raises error if locales loaded cannot be extracted from load path names" do
+    with_eager_mode do
+      @backend.reload!
+
+      contents = { de: { cat: 'katze' } }.to_yaml
+
+      with_translation_file_in_load_path(['fr_translation', '.yml'], nil, contents) do |file_path|
+        exception = assert_raises(I18n::InvalidFilenames) { I18n.t("foo.bar") }
+
+        expected_message = /#{Regexp.escape(file_path)} can only load translations for "fr"\. Found translations for: \[\:de\]/
+        assert_match expected_message, exception.message
+      end
+    end
+  end
+
+  private
+
+  def with_lazy_mode
+    @backend = I18n.backend = @lazy_mode_backend
+
+    yield
+  end
+
+  def with_eager_mode
+    @backend = I18n.backend = @eager_mode_backend
+
+    yield
+  end
+
+
+  def with_translation_file_in_load_path(name, tmpdir, file_contents)
+    @backend.reload!
+
+    path_to_dir = FileUtils.mkdir_p(File.join(Dir.tmpdir, tmpdir)).first if tmpdir
+    locale_file = Tempfile.new(name, path_to_dir)
+
+    locale_file.write(file_contents)
+    locale_file.rewind
+
+    I18n.load_path << locale_file.path
+
+    yield(locale_file.path)
+
+    I18n.load_path.delete(locale_file.path)
+  end
+end
+

--- a/test/test_data/locales/fr.yml
+++ b/test/test_data/locales/fr.yml
@@ -1,0 +1,3 @@
+fr:
+  animal:
+    dog: chien


### PR DESCRIPTION
### What's in this PR

This PR introduces a new `LazyLoadable` backend following the proposal written in https://github.com/ruby-i18n/i18n/issues/592.

### What does the `LazyLoadable` Backend offer?

This backend offers a performance optimization for environments where only a fraction of the app's translation data is actually required. Most notably, a local test environment.

As opposed to the `Simple` backend, this backend avoids loading all translations in the load path. Instead, it infers which files need to be loaded based on the current locale. To do so, it imposes a format on the files in the load path. They must abide by a specific format structure to enable the backend to reason about which files belong to which locale. We trade off the rigidity of the imposed format with the performance incentive achieved by only loading files that are needed.

**In other words, this backend avoids the cost of loading unnecessary translation files by carefully selecting only those files which are needed for the current locale. It lazily initializes translations on a per locale basis.**

### How does the `LazyLoadable` Backend work?

This backend trades off the expensive cost of `I/O` with the cost of perform string matching on files in the load path. It makes assumptions about which files belong to a locale and selectively loads only these files.

### How does the `LazyLoadable` Backend know which files belong to which locale?

It makes assumptions about how files are named. **Clients must abide by this naming system if they decide to use this backend.**

The heuristic used to bind a file to its locale can be defined as follows:
1) the filename is in the I18n load path
2) the filename ends in a supported extension (ie. .yml, .json, .po, .rb)
3) the filename starts with the locale identifier
4) the locale identifier and optional proceeding text is separated by an underscore, ie. "_".

### Working Through An Example

Assume an app's `I18n.load_path` consisted of the following files:

```
config/locales/en_001.yml
config/locales/en_002.yml
config/locales/en_003.yml
...
config/locales/en_n.yml
config/locales/fr_001.yml
config/locales/fr_002.yml
config/locales/fr_003.yml
...
config/locales/fr_n.yml
config/locales/de_001.yml
config/locales/de_002.yml
config/locales/de_003.yml
...
config/locales/de_n.yml
```

A test is run in the local environment which requires a single `:en` translation. Currently, when the `Simple` backend is initialized, all files will be loaded into memory.

This results in `3n` loads if we assume there are only 3 locales.

With the `LazyLoadable` backend, we can conventionally select only the `:en` translations resulting in `n` loads.

### When should someone use this backend?

The backend has two working modes: `lazy_load` and `eager_load`.

**This backend should only be enabled in test environments!**

When the mode is set to false, the backend behaves exactly like the Simple backend, with an additional check that the paths being loaded abide by the format. If paths can't be matched to the format, an error is raised.
 
It's particularly useful to enable for workloads that operate in the context of a single locale at a time and have many translations files for many locales. For instance, a large Rails workload would benefit from this backend in the local test environment.

### Benchmarks: Comparing the `Simple` backend to the `LazyLoadable` backend

A benchmark setup was used to compare the performance of these two backends.

**Table 1: Setup with 10 files per locale, 100 keys in each file:**

| Backend  | Work Performed                | User     | Sys      | Total    | Real     |
|----------|-------------------------------|----------|----------|----------|----------|
| Simple   | Eager load (:en)              | 0.012764 | 0.000721 | 0.013485 | 0.013503 |
| Simple   | 3 Eager loads (:en, :fr, :de) | 0.012364 | 0.000675 | 0.013039 | 0.013038 |
| LazyLoadable | Eager load (:en)              | 0.004820 | 0.000330 | 0.005150 | 0.005137 |
| LazyLoadable | 3 Eager loads (:en, :fr, :de) | 0.019816 | 0.000847 | 0.020663 | 0.020674 |

**Table 2: Setup with 100 files per locale, 1000 keys in each file:**

| Backend  | Work Performed                | User     | Sys      | Total    | Real     |
|----------|-------------------------------|----------|----------|----------|----------|
| Simple   | Eager load (:en)              | 1.342190 | 0.020641 | 1.362831 | 1.363569 |
| Simple   | 3 Eager loads (:en, :fr, :de) | 1.344860 | 0.018035 | 1.362895 | 1.363284 |
| LazyLoadable | Eager load (:en)              | 0.478600 | 0.011205 | 0.489805 | 0.489951 |
| LazyLoadable | 3 Eager loads (:en, :fr, :de) | 1.357584 | 0.026064 | 1.383648 | 1.384148 |

#### Evaluating the results

The `LazyLoadable` backend reduces working time as it avoids loading unnecessary files. In the case when loading for a single locale, we see that the `LazyLoadable` backend outperforms  `Simple`, 0.005 vs 0.013 in Table 1 and 0.4899 vs 1.363 in Table 2.

This time reduction is a function of the number of locales, so we see 3x improvements because we avoid loading 66% of the files. This scales with the number of files avoided.

Note: The `LazyLoadable` backend performs roughly on-par with the `Simple` backend when it needs to load all translations. There is additional overhead of string matching which brings down the performance in small workloads. It's negligible in any significant workloads compared to the time spent in `I/O`.

### Industry Proof

At Shopify, we've patched `ruby-i18n` locally to implement a similar strategy. We've observed close to **10x speed ups locally in specific tests and roughly 20% speeds across the suite.**

### Conclusions

This backend is designed to bring performance improvements to workloads with a large volume of locales, translation files, and translation keys.

It's designed for the local test environment, and is an opt-in backend.
