### PR TITLE
Minor `I18n.normalize_keys` improvement

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -338,11 +338,11 @@ module I18n
     def normalize_keys(locale, key, scope, separator = nil)
       separator ||= I18n.default_separator
 
-      keys = []
-      keys.concat normalize_key(locale, separator)
-      keys.concat normalize_key(scope, separator)
-      keys.concat normalize_key(key, separator)
-      keys
+      [
+        *normalize_key(locale, separator),
+        *normalize_key(scope, separator),
+        *normalize_key(key, separator)
+      ]
     end
 
     # Returns true when the passed locale, which can be either a String or a


### PR DESCRIPTION
Minor performance bump, as well as fewer objects allocated, when using `*` v. `concat` for normalizing keys -

📝  Last updated in https://github.com/ruby-i18n/i18n/commit/6425f554c2f5ea5c22365632d818f9f04239023d

<details>
<summary>Measurements</summary>

```ruby
# Ruby 2.7.5

require 'benchmark/ips'

report = Benchmark.ips do |x|
  x.report("concat") do
    ex = []
    ex.concat ['foo']
    ex.concat ['bar', 'baz']
    ex.concat ['quix']
    ex
  end
  x.report("splat") do
    [
      *['foo'],
      *['bar', 'baz'],
      *['quix']
    ]
  end
  x.compare!
Warming up --------------------------------------
              concat   185.470k i/100ms
               splat   467.395k i/100ms
Calculating -------------------------------------
              concat      2.176M (± 1.5%) i/s -     10.943M in   5.030233s
               splat      4.678M (± 2.0%) i/s -     23.837M in   5.098138s

Comparison:
               splat:  4677698.6 i/s
              concat:  2175917.9 i/s - 2.15x  (± 0.00) slower
```

```ruby
require 'memory_profiler'
n = 100

report1 = MemoryProfiler.report do
  n.times do
    ex = []
    ex.concat ['foo']
    ex.concat ['bar', 'baz']
    ex.concat ['quix']
    ex
  end
end

report1.pretty_print(scale_bytes: true, detailed_report: false)
# Total allocated: 48.00 kB (800 objects)
# Total retained:  0 B (0 objects)

report2 = MemoryProfiler.report do
  n.times do
    [
      *['foo'],
      *['bar', 'baz'],
      *['quix']
    ]
  end
end

report2.pretty_print(scale_bytes: true, detailed_report: false)
# Total allocated: 23.20 kB (500 objects)
# Total retained:  0 B (0 objects)
```

</details>