### PR TITLE
Revert #591, add a regression test for #617

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -23,7 +23,6 @@ module I18n
     exception_handler
     fallback
     fallback_in_progress
-    fallback_original_locale
     format
     object
     raise

--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -43,7 +43,7 @@ module I18n
         return super if options[:fallback_in_progress]
         default = extract_non_symbol_default!(options) if options[:default]
 
-        fallback_options = options.merge(:fallback_in_progress => true, fallback_original_locale: locale)
+        fallback_options = options.merge(:fallback_in_progress => true)
         I18n.fallbacks[locale].each do |fallback|
           begin
             catch(:exception) do
@@ -62,17 +62,6 @@ module I18n
 
         return super(locale, nil, options.merge(:default => default)) if default
         throw(:exception, I18n::MissingTranslation.new(locale, key, options))
-      end
-
-      def resolve(locale, object, subject, options = EMPTY_HASH)
-        return subject if options[:resolve] == false
-        return super unless subject.is_a?(Symbol)
-
-        result = catch(:exception) do
-          options.delete(:fallback_in_progress)
-          I18n.translate(subject, **options.merge(locale: options[:fallback_original_locale], throw: true))
-        end
-        result unless result.is_a?(MissingTranslation)
       end
 
       def extract_non_symbol_default!(options)

--- a/lib/i18n/tests/localization/procs.rb
+++ b/lib/i18n/tests/localization/procs.rb
@@ -74,7 +74,6 @@ module I18n
                 arg.strftime('%a, %d %b %Y')
               when Hash
                 arg.delete(:fallback_in_progress)
-                arg.delete(:fallback_original_locale)
                 arg.inspect
               else
                 arg.inspect

--- a/lib/i18n/tests/procs.rb
+++ b/lib/i18n/tests/procs.rb
@@ -53,13 +53,7 @@ module I18n
 
 
       def self.filter_args(*args)
-        args.map do |arg|
-          if arg.is_a?(Hash)
-            arg.delete(:fallback_in_progress)
-            arg.delete(:fallback_original_locale)
-          end
-          arg
-        end.inspect
+        args.map {|arg| arg.delete(:fallback_in_progress) if arg.is_a?(Hash) ; arg }.inspect
       end
     end
   end

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'pry'
 
 class I18nBackendFallbacksTranslateTest < I18n::TestCase
   class Backend < I18n::Backend::Simple
@@ -192,7 +193,7 @@ class I18nBackendFallbacksLocalizeTestWithMultipleThreads < I18n::TestCase
 end
 
 # See Issue #590
-class I18nBackendFallbacksSymbolReolveRestartsLookupAtOriginalLocale < I18n::TestCase
+class I18nBackendFallbacksSymbolResolveRestartsLookupAtOriginalLocale < I18n::TestCase
   class Backend < I18n::Backend::Simple
     include I18n::Backend::Fallbacks
   end
@@ -236,6 +237,29 @@ class I18nBackendFallbacksSymbolReolveRestartsLookupAtOriginalLocale < I18n::Tes
 
   test 'falls back to original locale when symbol resolved at fallback locale' do
     assert_equal({ 1 => 'S-Ɔ' }, I18n.t('calendars.gregorian.months.stand-alone.abbreviated', locale: :"ak-GH"))
+  end
+end
+
+# See Issue #617
+class RegressionTestFor617 < I18n::TestCase
+  class Backend < I18n::Backend::Simple
+    include I18n::Backend::Fallbacks
+  end
+
+  def setup
+    super
+    I18n.backend = Backend.new
+    I18n.enforce_available_locales = false
+    I18n.fallbacks = {:en=>[:en], :"en-US"=>[:"en-US", :en]}
+    I18n.locale = :'en-US'
+    store_translations(:"en-US", {})
+    store_translations(:en, :activerecord=>{:models=>{:product=>{:one=>"Product", :other=>"Products"}, :"product/ticket"=>{:one=>"Ticket", :other=>"Tickets"}}})
+  end
+
+  test 'model scope resolution' do
+    defaults = [:"product/ticket", :product, "Ticket"]
+    options = {:scope=>[:activerecord, :models], :count=>1, :default=> defaults}
+    assert_equal("Ticket", I18n.t(defaults.shift, **options))
   end
 end
 

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'pry'
 
 class I18nBackendFallbacksTranslateTest < I18n::TestCase
   class Backend < I18n::Backend::Simple
@@ -192,54 +191,6 @@ class I18nBackendFallbacksLocalizeTestWithMultipleThreads < I18n::TestCase
   end
 end
 
-# See Issue #590
-class I18nBackendFallbacksSymbolResolveRestartsLookupAtOriginalLocale < I18n::TestCase
-  class Backend < I18n::Backend::Simple
-    include I18n::Backend::Fallbacks
-  end
-
-  def setup
-    super
-    I18n.backend = Backend.new
-    I18n.enforce_available_locales = false
-    I18n.fallbacks = [:root]
-    store_translations(:ak,
-                       'calendars' => {
-                         'gregorian' => {
-                           'months' => {
-                             'format' => {
-                               'abbreviated' => {
-                                 1 => 'S-Ɔ'
-                                 # Other months omitted for brevity
-                               }
-                             }
-                           }
-                         }
-                       })
-    store_translations(:root,
-                       'calendars' => {
-                         'gregorian' => {
-                           'months' => {
-                             'format' => {
-                               'abbreviated' => :"calendars.gregorian.months.format.wide",
-                               'wide' => {
-                                 1 => 'M01'
-                                 # Other months omitted for brevity
-                               }
-                             },
-                             'stand-alone' => {
-                               'abbreviated' => :"calendars.gregorian.months.format.abbreviated"
-                             }
-                           }
-                         }
-                       })
-  end
-
-  test 'falls back to original locale when symbol resolved at fallback locale' do
-    assert_equal({ 1 => 'S-Ɔ' }, I18n.t('calendars.gregorian.months.stand-alone.abbreviated', locale: :"ak-GH"))
-  end
-end
-
 # See Issue #617
 class RegressionTestFor617 < I18n::TestCase
   class Backend < I18n::Backend::Simple
@@ -262,7 +213,6 @@ class RegressionTestFor617 < I18n::TestCase
     assert_equal("Ticket", I18n.t(defaults.shift, **options))
   end
 end
-
 
 class I18nBackendFallbacksLocalizeTest < I18n::TestCase
   class Backend < I18n::Backend::Simple


### PR DESCRIPTION
After #591, and with I18n v1.9.x versions, the fallbacks logic has broken. In this PR, I include a simple test to reproduce the issue as well as reverting #591.

cc @movermeyer / @jeffblake