### PR TITLE
Allow overriding of entry resolving entry resolving separate from defaults

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -35,7 +35,7 @@ module I18n
         if entry.nil? && options.key?(:default)
           entry = default(locale, key, options[:default], options)
         else
-          entry = resolve(locale, key, entry, options)
+          entry = resolve_entry(locale, key, entry, options)
         end
 
         count = options[:count]
@@ -154,6 +154,7 @@ module I18n
           end
           result unless result.is_a?(MissingTranslation)
         end
+        alias_method :resolve_entry, :resolve
 
         # Picks a translation from a pluralized mnemonic subkey according to English
         # pluralization rules :

--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -94,7 +94,7 @@ module I18n
               return nil unless result.has_key?(_key)
             end
             result = result[_key]
-            result = resolve(locale, _key, result, options.merge(:scope => nil)) if result.is_a?(Symbol)
+            result = resolve_entry(locale, _key, result, options.merge(:scope => nil)) if result.is_a?(Symbol)
             result
           end
         end

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -239,6 +239,28 @@ class I18nBackendFallbacksSymbolReolveRestartsLookupAtOriginalLocale < I18n::Tes
   end
 end
 
+# See Issue #617
+class RegressionTestFor617 < I18n::TestCase
+  class Backend < I18n::Backend::Simple
+    include I18n::Backend::Fallbacks
+  end
+
+  def setup
+    super
+    I18n.backend = Backend.new
+    I18n.enforce_available_locales = false
+    I18n.fallbacks = {:en=>[:en], :"en-US"=>[:"en-US", :en]}
+    I18n.locale = :'en-US'
+    store_translations(:"en-US", {})
+    store_translations(:en, :activerecord=>{:models=>{:product=>{:one=>"Product", :other=>"Products"}, :"product/ticket"=>{:one=>"Ticket", :other=>"Tickets"}}})
+  end
+
+  test 'model scope resolution' do
+    defaults = [:product, "Ticket"]
+    options = {:scope=>[:activerecord, :models], :count=>1, :default=> defaults}
+    assert_equal("Ticket", I18n.t(:"product/ticket", **options))
+  end
+end
 
 class I18nBackendFallbacksLocalizeTest < I18n::TestCase
   class Backend < I18n::Backend::Simple


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #617. Alternative to #620.

#591 was incorrect, since I didn't check/realize that `resolve` is called in three different cases:

1. When the value found in the translation file is a `Symbol` ([Code](https://github.com/ruby-i18n/i18n/blob/cbca32e3fa0f94306c079ab61df4436aab05a2bd/lib/i18n/backend/simple.rb#L97))
    * This was the case I handled in #591. In this case, you need/want to restart your search from the original fallback locale.
2. When a value is not found, then values from `defaults` are resolved. ([Code](https://github.com/ruby-i18n/i18n/blob/eb9dbf485f65ac68e730f52977be6af04f1e708b/lib/i18n/backend/base.rb#L130))
    * When resolving defaults, you want to do it only at the level of the current locale, before falling back.
    * i.e., Go through all `defaults` before falling back through `fallbacks` locales, keeping the behaviour as it has always been.
3. When the value found in the translation file is something else, especially a `Proc` ([Code](https://github.com/ruby-i18n/i18n/blob/eb9dbf485f65ac68e730f52977be6af04f1e708b/lib/i18n/backend/base.rb#L38))
    * This is the same case as `1.`, where you are resolving a entry, but I mention it separately since it is being called from a different place in the code.  

Prior to #591, there was no distinction between the cases. #591 should have introduced that distinction.
 
### What approach did you choose and why?

I added a `resolve_entry` method which can be overridden to handle the case of resolving an entry separately from resolving `defaults`. By default `resolve_entry` is an alias of `resolve`.

I then changed the calls to `resolve` to use `resolve_entry` in cases where they are resolving entries.

### What should reviewers focus on?

🤷

### The impact of these changes

Fixes #617.

### Testing

I added the regression test from #620 to show that it works with the existing Rails calls. 