### PR TITLE
Don't skip interpolate for the empty values.

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -184,11 +184,15 @@ module I18n
         #   method interpolates ["yes, %{user}", ["maybe no, %{user}, "no, %{user}"]], :user => "bartuz"
         #   # => "["yes, bartuz",["maybe no, bartuz", "no, bartuz"]]"
         def interpolate(locale, subject, values = EMPTY_HASH)
-          return subject if values.empty?
-
           case subject
-          when ::String then I18n.interpolate(subject, values)
-          when ::Array then subject.map { |element| interpolate(locale, element, values) }
+          when ::String
+            if I18n.config.interpolation_patterns.any? { |pattern| pattern =~ subject }
+              I18n.interpolate(subject, values)
+            else
+              subject
+            end
+          when ::Array
+            subject.map { |element| interpolate(locale, element, values) }
           else
             subject
           end

--- a/test/i18n/interpolate_test.rb
+++ b/test/i18n/interpolate_test.rb
@@ -42,6 +42,13 @@ class I18nInterpolateTest < I18n::TestCase
     end
   end
 
+  test "String interpolation raises an I18n::MissingInterpolationArgument when the string misses certain placeholder" do
+    store_translations(I18n.default_locale, "interpolation_missing" => '%{string} is missing')
+
+    assert_nothing_raised { I18n.t("interpolation_missing", string: "nothing") }
+    assert_raises(I18n::MissingInterpolationArgument) { I18n.t("interpolation_missing") }
+  end
+
   test "String interpolation does not raise when extra values were passed" do
     assert_nothing_raised do
       assert_equal "Masao Mutoh", I18n.interpolate("%{first} %{last}", :first => 'Masao', :last => 'Mutoh', :salutation => 'Mr.' )


### PR DESCRIPTION
The `I18n.t` method won't raise `I18n::MissingInterpolationArgument` error if the given options are empty, which is not as expected.

e.g. 
```yml
en:
    greeting: "Hello %{firstname} %{lastname}"
```

```ruby
I18n.t("greeting", firstname: "Michael", lastname: "Jordan") # => "Hello Michael Jordan"
I18n.t("greeting") # => "Hello %{firstname} %{lastname}"
I18n.t("greeting", firstname: "Michael") # => I18n::MissingInterpolationArgument
```