### PR TITLE
Consistently return array from bulk lookup, even if translation(s) missing

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -214,18 +214,12 @@ module I18n
 
       backend = config.backend
 
-      result = catch(:exception) do
-        if key.is_a?(Array)
-          key.map { |k| backend.translate(locale, k, options) }
-        else
-          backend.translate(locale, key, options)
+      if key.is_a?(Array)
+        key.map do |k|
+          translate_key(k, throw, raise, locale, backend, options)
         end
-      end
-
-      if result.is_a?(MissingTranslation)
-        handle_exception((throw && :throw || raise && :raise), result, locale, key, options)
       else
-        result
+        translate_key(key, throw, raise, locale, backend, options)
       end
     end
     alias :t :translate
@@ -363,6 +357,18 @@ module I18n
     end
 
   private
+
+    def translate_key(key, throw, raise, locale, backend, options)
+      result = catch(:exception) do
+        backend.translate(locale, key, options)
+      end
+
+      if result.is_a?(MissingTranslation)
+        handle_exception((throw && :throw || raise && :raise), result, locale, key, options)
+      else
+        result
+      end
+    end
 
     # Any exceptions thrown in translate will be sent to the @@exception_handler
     # which can be a Symbol, a Proc or any other Object unless they're forced to

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -212,6 +212,13 @@ class I18nTest < I18n::TestCase
     assert_equal "translation missing: en.bogus", I18n.t(:bogus)
   end
 
+  test "translate given multiple bogus keys returns the first error message" do
+    assert_equal(
+      "translation missing: en.bogus",
+      I18n.t([:bogus, :also_bogus]),
+    )
+  end
+
   test "translate given an empty string as a key raises an I18n::ArgumentError" do
     assert_raises(I18n::ArgumentError) { I18n.t("") }
   end

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -212,9 +212,9 @@ class I18nTest < I18n::TestCase
     assert_equal "translation missing: en.bogus", I18n.t(:bogus)
   end
 
-  test "translate given multiple bogus keys returns the first error message" do
+  test "translate given multiple bogus keys returns an array of error messages" do
     assert_equal(
-      "translation missing: en.bogus",
+      ["translation missing: en.bogus", "translation missing: en.also_bogus"],
       I18n.t([:bogus, :also_bogus]),
     )
   end


### PR DESCRIPTION
In the event of we fail to lookup one or more keys during a bulk lookup, we should still return an array of translation results.

Currently, doing a bulk lookup for multiple keys returns only the "translation missing" string for the first key.

- The first commit adds a test describing the existing behavior.
- The second commit fixes it and updates the test. All other tests appear unaffected.