### PR TITLE
Add support for CLDR data in `I18n::Backend::Pluralization`

### DIFF
--- a/test/backend/pluralization_test.rb
+++ b/test/backend/pluralization_test.rb
@@ -9,16 +9,22 @@ class I18nBackendPluralizationTest < I18n::TestCase
   def setup
     super
     I18n.backend = Backend.new
-    @rule = lambda { |n| n == 1 ? :one : n == 0 || (2..10).include?(n % 100) ? :few : (11..19).include?(n % 100) ? :many : :other }
+    @rule = lambda { |n| n % 10 == 1 && n % 100 != 11 ? :one : n == 0 || (2..10).include?(n % 100) ? :few : (11..19).include?(n % 100) ? :many : :other }
     store_translations(:xx, :i18n => { :plural => { :rule => @rule } })
-    @entry = { :zero => 'zero', :one => 'one', :few => 'few', :many => 'many', :other => 'other' }
+    @entry = { :"0" => 'none', :"1" => 'single', :one => 'one', :few => 'few', :many => 'many', :other => 'other' }
   end
 
   test "pluralization picks a pluralizer from :'i18n.pluralize'" do
     assert_equal @rule, I18n.backend.send(:pluralizer, :xx)
   end
 
-  test "pluralization picks :one for 1" do
+  test "pluralization picks the explicit 1 rule for count == 1, the explicit rule takes priority over the matching :one rule" do
+    assert_equal 'single', I18n.t(:count => 1, :default => @entry, :locale => :xx)
+    assert_equal 'single', I18n.t(:count => 1.0, :default => @entry, :locale => :xx)
+  end
+
+  test "pluralization picks :one for 1, since in this case that is the matching rule for 1 (when there is no explicit 1 rule)" do
+    @entry.delete(:"1")
     assert_equal 'one', I18n.t(:count => 1, :default => @entry, :locale => :xx)
   end
 
@@ -30,13 +36,20 @@ class I18nBackendPluralizationTest < I18n::TestCase
     assert_equal 'many', I18n.t(:count => 11, :default => @entry, :locale => :xx)
   end
 
-  test "pluralization picks zero for 0 if the key is contained in the data" do
-    assert_equal 'zero', I18n.t(:count => 0, :default => @entry, :locale => :xx)
+  test "pluralization picks explicit 0 rule for count == 0, since the explicit rule takes priority over the matching :few rule" do
+    assert_equal 'none', I18n.t(:count => 0, :default => @entry, :locale => :xx)
+    assert_equal 'none', I18n.t(:count => 0.0, :default => @entry, :locale => :xx)
+    assert_equal 'none', I18n.t(:count => -0, :default => @entry, :locale => :xx)
   end
 
-  test "pluralization picks few for 0 if the key is not contained in the data" do
-    @entry.delete(:zero)
+  test "pluralization picks :few for 0 (when there is no explicit 0 rule)" do
+    @entry.delete(:"0")
     assert_equal 'few', I18n.t(:count => 0, :default => @entry, :locale => :xx)
+  end
+
+  test "pluralization does Lateral Inheritance to :other to cover missing data" do
+    @entry.delete(:many)
+    assert_equal 'other', I18n.t(:count => 11, :default => @entry, :locale => :xx)
   end
 
   test "pluralization picks one for 1 if the entry has attributes hash on unknown locale" do


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/ruby-i18n/i18n/issues/629

### What approach did you choose and why?

* Dropped the incorrect special case of `count == 0` using the `zero` key
* Added handling for CLDR's [explicit 0 and 1 keys](https://unicode-org.github.io/cldr/ldml/tr35-numbers.html#Explicit_0_1_rules)
* Added CLDR's [lateral inheritance](http://www.unicode.org/reports/tr35/#Lateral_Inheritance) of using the `other` plural category 

### What should reviewers focus on?

This is a breaking change. Anyone using the `zero` key in locales that don't require the `zero` key will have to change the key to use the explicit "0" key instead.

### Q&A

**Q:** Are `0` & `1` they only special cases, or can one introduce others? Perhaps `2: I have a pair of cars`
**A:** It _might_ be allowed, depending on how you read the spec... but the spec only mentions `0` and `1`, the [LDML DTD](https://github.com/unicode-org/cldr/blob/86fd8773ed0f3c4da15be368d2ba3b5683ed9f93/common/dtd/ldml.dtd#L2441) only considers `0` and `1` to be valid, and CLDR has only ever used `0` and `1`. I left support for arbitrary numbers out of this PR, as I figure that it would be better to be restrictive with what we accept right now. It's an easy change to accept other values if it turns out to be desirable.

### The impact of these changes

Pluralization lookups will will support CLDR's data.
The problematic use of the `zero` key will be resolved.
Fixes https://github.com/ruby-i18n/i18n/issues/629