### PR TITLE
Fix typos

### DIFF
--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -107,7 +107,7 @@ module I18n
       private
 
         # Overwrite on_fallback to add specified logic when the fallback succeeds.
-        def on_fallback(_original_locale, _fallback_locale, _key, _optoins)
+        def on_fallback(_original_locale, _fallback_locale, _key, _options)
           nil
         end
     end

--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -38,7 +38,7 @@ module I18n
     end
 
     # Returns an array of locales for which translations are available.
-    # Unless you explicitely set these through I18n.available_locales=
+    # Unless you explicitly set these through I18n.available_locales=
     # the call will be delegated to the backend.
     def available_locales
       @@available_locales ||= nil

--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -106,7 +106,7 @@ module I18n
     # if you don't care about arity.
     #
     # == Example:
-    # You can supress raising an exception and return string instead:
+    # You can suppress raising an exception and return string instead:
     #
     #   I18n.config.missing_interpolation_argument_handler = Proc.new do |key|
     #     "#{key} is missing"

--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -24,7 +24,7 @@ module I18n
         been set is likely to display text from the wrong locale to some users.
 
         If you have a legitimate reason to access i18n data outside of the user flow, you can do so by passing
-        the desired locale explictly with the `locale` argument, e.g. `I18n.#{method}(..., locale: :en)`
+        the desired locale explicitly with the `locale` argument, e.g. `I18n.#{method}(..., locale: :en)`
       MESSAGE
     end
   end

--- a/lib/i18n/locale/tag/simple.rb
+++ b/lib/i18n/locale/tag/simple.rb
@@ -1,5 +1,5 @@
 # Simple Locale tag implementation that computes subtags by simply splitting
-# the locale tag at '-' occurences.
+# the locale tag at '-' occurrences.
 module I18n
   module Locale
     module Tag

--- a/lib/i18n/tests/basics.rb
+++ b/lib/i18n/tests/basics.rb
@@ -26,7 +26,7 @@ module I18n
         assert_equal I18n.available_locales, I18n.backend.available_locales
       end
 
-      test "available_locales memoizes when set explicitely" do
+      test "available_locales memoizes when set explicitly" do
         I18n.backend.expects(:available_locales).never
         I18n.available_locales = [:foo]
         I18n.backend.store_translations('de', :bar => 'baz')
@@ -34,7 +34,7 @@ module I18n
         assert_equal [:foo], I18n.available_locales
       end
 
-      test "available_locales delegates to the backend when not set explicitely" do
+      test "available_locales delegates to the backend when not set explicitly" do
         original_available_locales_value = I18n.backend.available_locales
         I18n.backend.expects(:available_locales).returns(original_available_locales_value).twice
         assert_equal I18n.backend.available_locales, I18n.available_locales

--- a/test/backend/chain_test.rb
+++ b/test/backend/chain_test.rb
@@ -78,7 +78,7 @@ class I18nBackendChainTest < I18n::TestCase
       "Bah"], I18n.t([:formats, :plural_2, :bah], :default => 'Bah')
   end
 
-  test "store_translations options are not dropped while transfering to backend" do
+  test "store_translations options are not dropped while transferring to backend" do
     @first.expects(:store_translations).with(:foo, {:bar => :baz}, {:option => 'persists'})
     I18n.backend.store_translations :foo, {:bar => :baz}, {:option => 'persists'}
   end

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -192,7 +192,7 @@ class I18nBackendFallbacksLocalizeTestWithMultipleThreads < I18n::TestCase
 end
 
 # See Issue #590
-class I18nBackendFallbacksSymbolReolveRestartsLookupAtOriginalLocale < I18n::TestCase
+class I18nBackendFallbacksSymbolResolveRestartsLookupAtOriginalLocale < I18n::TestCase
   class Backend < I18n::Backend::Simple
     include I18n::Backend::Fallbacks
   end

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -29,7 +29,7 @@ class I18nBackendFallbacksTranslateTest < I18n::TestCase
   end
 
   test "keeps the count option when defaulting to a different key" do
-    assert_equal 'Interpolate 5 10', I18n.t(:non_existant, default: :interpolate_count, count: 10, value: 5)
+    assert_equal 'Interpolate 5 10', I18n.t(:non_existent, default: :interpolate_count, count: 10, value: 5)
   end
 
   test "returns the :de translation for a missing :'de-DE' when :default is a String" do

--- a/test/i18n/middleware_test.rb
+++ b/test/i18n/middleware_test.rb
@@ -16,7 +16,7 @@ class I18nMiddlewareTest < I18n::TestCase
     refute_equal updated_i18n_config_object_id, old_i18n_config_object_id
   end
 
-  test "succesfully resets i18n locale to default locale by defining new config" do
+  test "successfully resets i18n locale to default locale by defining new config" do
     @middleware.call({})
 
     assert_equal :fr, I18n.locale

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -379,7 +379,7 @@ class I18nTest < I18n::TestCase
     assert_equal I18n.default_locale, I18n.locale
   end
 
-  test "I18n.translitarate handles I18n::ArgumentError exception" do
+  test "I18n.transliterate handles I18n::ArgumentError exception" do
     I18n::Backend::Transliterator.stubs(:get).raises(I18n::ArgumentError)
     I18n.exception_handler.expects(:call).raises(I18n::ArgumentError)
     assert_raises(I18n::ArgumentError) {
@@ -387,7 +387,7 @@ class I18nTest < I18n::TestCase
     }
   end
 
-  test "I18n.translitarate raises I18n::ArgumentError exception" do
+  test "I18n.transliterate raises I18n::ArgumentError exception" do
     I18n::Backend::Transliterator.stubs(:get).raises(I18n::ArgumentError)
     I18n.exception_handler.expects(:call).never
     assert_raises(I18n::ArgumentError) {


### PR DESCRIPTION
### What are you trying to accomplish?

While working in `ruby-i18n/i18n` I noticed some typos. This PR fixes them.

### What approach did you choose and why?

Instead of fixing them piecemeal, I've used a spell-checker to find typos across the entire repo and made the fixes.

### What should reviewers focus on?

🤷 You may want to squash these together before merging.

### The impact of these changes

Nothing. Just fixing nits.