### PR TITLE
Fix symbol resolving with pluralization

### DIFF
--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -94,7 +94,7 @@ module I18n
               return nil unless result.has_key?(_key)
             end
             result = result[_key]
-            result = resolve_entry(locale, _key, result, options.merge(:scope => nil)) if result.is_a?(Symbol)
+            result = resolve_entry(locale, _key, result, Utils.except(options.merge(:scope => nil), :count)) if result.is_a?(Symbol)
             result
           end
         end

--- a/test/backend/pluralization_test.rb
+++ b/test/backend/pluralization_test.rb
@@ -47,4 +47,14 @@ class I18nBackendPluralizationTest < I18n::TestCase
   test "Fallbacks can pick up rules from fallback locales, too" do
     assert_equal @rule, I18n.backend.send(:pluralizer, :'xx-XX')
   end
+
+  test "linked lookup works with pluralization backend" do
+    I18n.backend.store_translations(:xx, {
+      :automobiles => :autos,
+      :autos => :cars,
+      :cars => { :porsche => { :one => "I have %{count} Porsche 🚗", :other => "I have %{count} Porsches 🚗" } }
+    })
+    assert_equal "I have 1 Porsche 🚗", I18n.t(:'automobiles.porsche', count: 1, :locale => :xx)
+    assert_equal "I have 20 Porsches 🚗", I18n.t(:'automobiles.porsche', count: 20, :locale => :xx)
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #635. See #635 for discussion of the history of attempts to fix it.   

### What approach did you choose and why?

Instead of removing the `count` param within the Symbol resolving code of `Backend::Base` (as done in #480, then reverted), we remove the `count` parameter within the lookup code of `Backend::Simple`.

### The impact of these changes

Resolution of Symbols that point to pluralization contexts will work for `Backend::Pluralization` (with a `i18n.plural.rule` entry).

### Testing

Thankfully, each stage of [the saga](https://github.com/ruby-i18n/i18n/issues/635) that lead to this PR, the tests for the failing cases were added:

* #480 introduced a test for `Symbol` resolution
* #503 introduced a test for `Symbol` resolution in defaults with `count` parameter

So we can have confidence that at least all the known cases are covered.

I added a test that is similar to the one added in #480, but while using the `Backend::Pluralization` and not `Backend::Base`. This covers the case that was missing that would have caught the issue with the revert done in https://github.com/ruby-i18n/i18n/commit/1b5e34553003ca3b42b842769e86c98d5e3b71d4.

Anecdotally, I've tested it with our usage of the [`ruby-cldr`](https://github.com/ruby-i18n/ruby-cldr) exported data, (which contains a lot of aliases/`Symbol`s from the CLDR data), and with this patch lookups using `Backend::Pluralization` no longer fail.