### PR TITLE
Revert #503 changes for `Backend::Base`

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -166,7 +166,7 @@ module I18n
         # Other backends can implement more flexible or complex pluralization rules.
         def pluralize(locale, entry, count)
           entry = entry.reject { |k, _v| k == :attributes } if entry.is_a?(Hash)
-          return entry unless entry.is_a?(Hash) && count && entry.values.none? { |v| v.is_a?(Hash) }
+          return entry unless entry.is_a?(Hash) && count
 
           key = pluralization_key(entry, count)
           raise InvalidPluralizationData.new(entry, count, key) unless entry.has_key?(key)

--- a/test/backend/pluralization_test.rb
+++ b/test/backend/pluralization_test.rb
@@ -44,6 +44,23 @@ class I18nBackendPluralizationTest < I18n::TestCase
     assert_equal 'one', I18n.t(:count => 1, :default => @entry, :locale => :pirate)
   end
 
+  test "Nested keys within pluralization context" do
+    store_translations(:xx,
+      :stars => {
+        one: "%{count} star",
+        other: "%{count} stars",
+        special: {
+          one: "%{count} special star",
+          other: "%{count} special stars",
+        }
+      }
+    )
+    assert_equal "1 star", I18n.t('stars', count: 1, :locale => :xx)
+    assert_equal "20 stars", I18n.t('stars', count: 20, :locale => :xx)
+    assert_equal "1 special star", I18n.t('stars.special', count: 1, :locale => :xx)
+    assert_equal "20 special stars", I18n.t('stars.special', count: 20, :locale => :xx)
+  end
+
   test "Fallbacks can pick up rules from fallback locales, too" do
     assert_equal @rule, I18n.backend.send(:pluralizer, :'xx-XX')
   end

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -209,6 +209,23 @@ class I18nBackendSimpleTest < I18n::TestCase
     assert_equal true, I18n.backend.initialized?
   end
 
+  test "Nested keys within pluralization context" do
+    store_translations(:en,
+      :stars => {
+        one: "%{count} star",
+        other: "%{count} stars",
+        special: {
+          one: "%{count} special star",
+          other: "%{count} special stars",
+        }
+      }
+    )
+    assert_equal "1 star", I18n.t('stars', count: 1, :locale => :en)
+    assert_equal "20 stars", I18n.t('stars', count: 20, :locale => :en)
+    assert_equal "1 special star", I18n.t('stars.special', count: 1, :locale => :en)
+    assert_equal "20 special stars", I18n.t('stars.special', count: 20, :locale => :en)
+  end
+
   test "returns localized string given missing pluralization data" do
     assert_equal 'baz', I18n.t('foo.bar', count: 1)
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #514. See #635 for discussion of how this situation came to be.

### What approach did you choose and why?

Simply a revert of the changes to `Backend::Base` in #503, similar to the revert done for `Backend::Pluralization` in https://github.com/ruby-i18n/i18n/commit/1b5e34553003ca3b42b842769e86c98d5e3b71d4.

### The impact of these changes

Keys nested within pluralization contexts will once again work for those using `Backend::Base`