### PR TITLE
Add support for meridian indicators on `Date` objects

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -282,8 +282,8 @@ module I18n
             when '%^b' then I18n.t!(:"date.abbr_month_names",               :locale => locale, :format => format)[object.mon].upcase
             when '%B' then I18n.t!(:"date.month_names",                     :locale => locale, :format => format)[object.mon]
             when '%^B' then I18n.t!(:"date.month_names",                    :locale => locale, :format => format)[object.mon].upcase
-            when '%p' then I18n.t!(:"time.#{object.hour < 12 ? :am : :pm}", :locale => locale, :format => format).upcase if object.respond_to? :hour
-            when '%P' then I18n.t!(:"time.#{object.hour < 12 ? :am : :pm}", :locale => locale, :format => format).downcase if object.respond_to? :hour
+            when '%p' then I18n.t!(:"time.#{(object.respond_to?(:hour) ? object.hour : 0) < 12 ? :am : :pm}", :locale => locale, :format => format).upcase
+            when '%P' then I18n.t!(:"time.#{(object.respond_to?(:hour) ? object.hour : 0) < 12 ? :am : :pm}", :locale => locale, :format => format).downcase
             end
           end
         rescue MissingTranslationData => e

--- a/lib/i18n/tests/localization/date.rb
+++ b/lib/i18n/tests/localization/date.rb
@@ -34,6 +34,11 @@ module I18n
           assert_equal 'Sa', I18n.l(@date, :format => '%a', :locale => :de)
         end
 
+        test "localize Date: given an meridian indicator format it returns the correct meridian indicator" do
+          assert_equal 'AM', I18n.l(@date, :format => '%p', :locale => :de)
+          assert_equal 'am', I18n.l(@date, :format => '%P', :locale => :de)
+        end
+
         test "localize Date: given an abbreviated and uppercased day name format it returns the correct abbreviated day name in upcase" do
           assert_equal 'sa'.upcase, I18n.l(@date, :format => '%^a', :locale => :de)
         end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #639 

### What approach did you choose and why?

Assume that the `hour` of a `Date` is always `0`. Reading the source for `Date`, it seems that [`hour` is set to `0` and cannot be changed](https://github.com/ruby/ruby/blob/8d40ede2e005439cbc84abfd50c98932a33448f4/ext/date/date_core.c#L9632), regardless of how you create the `Date`.

My higher-level attempts also failed to set it to anything (adding confidence that I didn't misread the source. For example:

```ruby
(byebug) DateTime.jd(2451944.45).to_datetime.iso8601
"2001-02-03T10:48:00+00:00" # Note: halfway through the day
(byebug) Date.jd(2451944.45).to_datetime.iso8601
"2001-02-03T00:00:00+00:00" # but not when using `Date`
```

`localize` is [only meant for `Date`, `DateTime`, and `Time` objects anyway](https://github.com/ruby-i18n/i18n/blob/9071340a4c19da81aba924dc78623d8f7c04cded/lib/i18n/backend/base.rb#L79), so I'm not concerned. Besides, if one were to pass in a different object into `localize` that didn't respond to `hour`, then defaulting to 0 would be consistent with the values used in other date libraries. 🤷

### What should reviewers focus on?

Is there a better way to do this? 

Another way to do this would be to bypass the private method safety for `Date` objects by using `send`:

```diff
- when '%p' then I18n.t!(:"time.#{object.hour < 12 ? :am : :pm}", :locale => locale, :format => format).upcase if object.respond_to? :hour
+ when '%p' then I18n.t!(:"time.#{object.send(:hour) < 12 ? :am : :pm}", :locale => locale, :format => format).upcase if object.respond_to?(:hour) || object.is_a?(::Date)
```

Technically this would run the risk of Ruby changing the private implementation of `Date#hour`, but that feels like it could be an acceptable risk to me? 

I mostly chose the 0 defaulting way since it felt cleaner and didn't rely on `send`, but I have no strong preferences either way. I'm happy to change it if people feel strongly otherwise.

### The impact of these changes

Formats with Meridian indicators will once again work with `Date` objects. 