### PR TITLE
Fix load_path example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ gem 'i18n'
 Then configure I18n with some translations, and a default locale:
 
 ```ruby
-I18n.load_path << Dir[File.expand_path("config/locales") + "/*.yml"]
+I18n.load_path += Dir[File.expand_path("config/locales") + "/*.yml"]
 I18n.default_locale = :en # (note that `en` is already the default!)
 ```
 


### PR DESCRIPTION
`Dir[..]` returns an array, and `I18n.load_path` is already an array, so we should append the array elements rather than the whole thing.