### PR TITLE
Allow passing scope argument to exists?

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -66,7 +66,7 @@ module I18n
       end
 
       def exists?(locale, key, options = EMPTY_HASH)
-        lookup(locale, key) != nil
+        lookup(locale, key, options[:scope]) != nil
       end
 
       # Acts the same as +strftime+, but uses a localized version of the

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -303,6 +303,10 @@ class I18nTest < I18n::TestCase
     assert_equal true, I18n.exists?(:currency, :nl)
   end
 
+  test "exists? given an existing key and a scope will return true" do
+    assert_equal true, I18n.exists?(:delimiter, scope: [:currency, :format])
+  end
+
   test "exists? given a non-existing key and an existing locale will return false" do
     assert_equal false, I18n.exists?(:bogus, :nl)
   end


### PR DESCRIPTION
`I18n.t` and `I18n.t!` both accept a `scope` argument that enables translation of a key within a particular namespace.

Add the same argument to `exists?` method, so that both `I18n.t` and `I18n.exists?` can be used with the same call pattern.