### PR TITLE
Return same string object when no interpolations were made

### DIFF
--- a/lib/i18n/interpolate/ruby.rb
+++ b/lib/i18n/interpolate/ruby.rb
@@ -28,7 +28,11 @@ module I18n
 
     def interpolate_hash(string, values)
       pattern = INTERPOLATION_PATTERNS_CACHE[config.interpolation_patterns]
-      string.gsub(pattern) do |match|
+      interpolated = false
+
+      interpolated_string = string.gsub(pattern) do |match|
+        interpolated = true
+
         if match == '%%'
           '%'
         else
@@ -42,6 +46,8 @@ module I18n
           $3 ? sprintf("%#{$3}", value) : value
         end
       end
+
+      interpolated ? interpolated_string : string
     end
   end
 end

--- a/test/i18n/interpolate_test.rb
+++ b/test/i18n/interpolate_test.rb
@@ -65,8 +65,14 @@ class I18nInterpolateTest < I18n::TestCase
     end
 
   end
+
   test "with String subclass that redefined gsub method" do
     assert_equal "Hello mars world", I18n.interpolate(RailsSafeBuffer.new("Hello %{planet} world"), :planet => 'mars') 
+  end
+
+  test "with String subclass that redefined gsub method returns same object if no interpolations" do
+    string = RailsSafeBuffer.new("Hello world")
+    assert_same string, I18n.interpolate(string, :planet => 'mars')
   end
 end
 


### PR DESCRIPTION
See for the details - https://github.com/rails/rails/issues/47421

Even when there are no interpolations, `gsub` turns `SafeBuffer` into a `String` - https://github.com/rails/rails/blob/6af9cba73db6296ab9aec7dbeae1e193ea69f09f/activesupport/lib/active_support/core_ext/string/output_safety.rb#L169
So we need to preserve the original "string" object.