### PR TITLE
Properly stub constants

### DIFF
--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -501,18 +501,14 @@ class I18nTest < I18n::TestCase
 
   test "can reserve a key" do
     begin
-      reserved_keys_were = I18n::RESERVED_KEYS.dup
+      stub_const(I18n, :RESERVED_KEYS, []) do
+        I18n.reserve_key(:foo)
+        I18n.reserve_key("bar")
 
-      assert !I18n::RESERVED_KEYS.include?(:foo)
-      assert !I18n::RESERVED_KEYS.include?(:bar)
-
-      I18n.reserve_key(:foo)
-      I18n.reserve_key("bar")
-
-      assert I18n::RESERVED_KEYS.include?(:foo)
-      assert I18n::RESERVED_KEYS.include?(:bar)
+        assert I18n::RESERVED_KEYS.include?(:foo)
+        assert I18n::RESERVED_KEYS.include?(:bar)
+      end
     ensure
-      I18n::RESERVED_KEYS = reserved_keys_were
       I18n.instance_variable_set(:@reserved_keys_pattern, nil)
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,6 +44,16 @@ class I18n::TestCase < Minitest::Test
   def locales_dir
     File.dirname(__FILE__) + '/test_data/locales'
   end
+
+  def stub_const(klass, constant, new_value)
+    old_value = klass.const_get(constant)
+    klass.send(:remove_const, constant)
+    klass.const_set(constant, new_value)
+    yield
+  ensure
+    klass.send(:remove_const, constant)
+    klass.const_set(constant, old_value)
+  end
 end
 
 class DummyRackApp


### PR DESCRIPTION
When running tests, ruby warns about redefining constants:
```
.............................................................................................
.............................................................................................
..................................................../Users/fatkodima/Desktop/oss/i18n/test/i1
8n_test.rb:515: warning: already initialized constant I18n::RESERVED_KEYS
/Users/fatkodima/Desktop/oss/i18n/lib/i18n.rb:19: warning: previous definition of RESERVED_KEYS was here
.............................................................................................................................
```