### PR TITLE
Optimize `I18n.t`

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -331,12 +331,11 @@ module I18n
     # keys are Symbols.
     def normalize_keys(locale, key, scope, separator = nil)
       separator ||= I18n.default_separator
+      locale = locale.to_sym if locale
 
-      [
-        *normalize_key(locale, separator),
-        *normalize_key(scope, separator),
-        *normalize_key(key, separator)
-      ]
+      result = [locale]
+      result.concat(normalize_key(scope, separator)) if scope
+      result.concat(normalize_key(key, separator))
     end
 
     # Returns true when the passed locale, which can be either a String or a

--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -54,7 +54,7 @@ module I18n
         end
 
         deep_interpolation = options[:deep_interpolation]
-        values = Utils.except(options, *RESERVED_KEYS)
+        values = Utils.except(options, *RESERVED_KEYS) unless options.empty?
         if values
           entry = if deep_interpolation
             deep_interpolate(locale, entry, values)
@@ -123,7 +123,12 @@ module I18n
         # first translation that can be resolved. Otherwise it tries to resolve
         # the translation directly.
         def default(locale, object, subject, options = EMPTY_HASH)
-          options = options.reject { |key, value| key == :default }
+          if options.size == 1 && options.has_key?(:default)
+            options = {}
+          else
+            options = Utils.except(options, :default)
+          end
+
           case subject
           when Array
             subject.each do |item|

--- a/lib/i18n/interpolate/ruby.rb
+++ b/lib/i18n/interpolate/ruby.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # heavily based on Masao Mutoh's gettext String interpolation extension
 # http://github.com/mutoh/gettext/blob/f6566738b981fe0952548c421042ad1e0cdfb31e/lib/gettext/core_ext/string.rb
 
@@ -10,6 +12,11 @@ module I18n
   INTERPOLATION_PATTERN = Regexp.union(DEFAULT_INTERPOLATION_PATTERNS)
   deprecate_constant :INTERPOLATION_PATTERN
 
+  INTERPOLATION_PATTERNS_CACHE = Hash.new do |hash, patterns|
+    hash[patterns] = Regexp.union(patterns)
+  end
+  private_constant :INTERPOLATION_PATTERNS_CACHE
+
   class << self
     # Return String or raises MissingInterpolationArgument exception.
     # Missing argument's logic is handled by I18n.config.missing_interpolation_argument_handler.
@@ -20,7 +27,8 @@ module I18n
     end
 
     def interpolate_hash(string, values)
-      string.gsub(Regexp.union(config.interpolation_patterns)) do |match|
+      pattern = INTERPOLATION_PATTERNS_CACHE[config.interpolation_patterns]
+      string.gsub(pattern) do |match|
         if match == '%%'
           '%'
         else


### PR DESCRIPTION
### Benchmarks
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "benchmark-ips"
  gem "i18n", path: "~/Desktop/oss/i18n"
end

require "i18n"

I18n.backend = I18n::Backend::Simple.new
I18n.backend.store_translations(:en, :foo => 'Foo in :en', :bar => 'Bar in :en', :buz => 'Buz in :en', :interpolate => 'Interpolate %{value}', :interpolate_count => 'Interpolate %{value} %{count}')

puts "Key exists\n"
Benchmark.ips do |x|
  x.report("original") do
    I18n.translate(:foo, locale: :en)
  end

  x.report("optimized") do
    I18n.translate_optimized(:foo, locale: :en)
  end

  x.compare!
end

puts "\nMissing key and default\n"
Benchmark.ips do |x|
  x.report("original") do
    I18n.translate(:missing, default: "foo")
  end

  x.report("optimized") do
    I18n.translate_optimized(:missing, default: "foo")
  end

  x.compare!
end

puts "\nInterpolation\n"
Benchmark.ips do |x|
  x.report("original") do
    I18n.translate(:interpolate, value: "foo")
  end

  x.report("optimized") do
    I18n.translate_optimized(:interpolate, value: "foo")
  end

  x.compare!
end
```

### Results
```
Warming up --------------------------------------
            original    18.193k i/100ms
           optimized    22.853k i/100ms
Calculating -------------------------------------
            original    182.271k (± 1.8%) i/s -    927.843k in   5.092162s
           optimized    235.982k (± 1.8%) i/s -      1.188M in   5.037393s

Comparison:
           optimized:   235982.5 i/s
            original:   182271.0 i/s - 1.29x  slower


Missing key and default
Warming up --------------------------------------
            original    14.985k i/100ms
           optimized    16.688k i/100ms
Calculating -------------------------------------
            original    148.773k (± 1.5%) i/s -    749.250k in   5.037379s
           optimized    166.369k (± 1.8%) i/s -    834.400k in   5.017022s

Comparison:
           optimized:   166368.8 i/s
            original:   148773.1 i/s - 1.12x  slower


Interpolation
Warming up --------------------------------------
            original     2.240k i/100ms
           optimized     8.674k i/100ms
Calculating -------------------------------------
            original     22.684k (± 3.6%) i/s -    114.240k in   5.042754s
           optimized     87.651k (± 2.5%) i/s -    442.374k in   5.050116s

Comparison:
           optimized:    87651.2 i/s
            original:    22684.0 i/s - 3.86x  slower
```