### PR TITLE
Fix I18n::Locale::Fallbacks not initializing itself on Ruby 3

### DIFF
--- a/lib/i18n/locale/fallbacks.rb
+++ b/lib/i18n/locale/fallbacks.rb
@@ -74,6 +74,7 @@ module I18n
               @map[from] << _to.to_sym
             end
           end
+          replace @map
         else
           @map.map(*args, &block)
         end


### PR DESCRIPTION
Implements and closes #645. Sorry if I'm missing something.