### PR TITLE
Add more helpful translation error when :default option is provided.

### DIFF
--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -47,7 +47,7 @@ module I18n
 
   class MissingTranslation < ArgumentError
     module Base
-      PERMITTED_KEYS = [:scope].freeze
+      PERMITTED_KEYS = [:scope, :default].freeze
 
       attr_reader :locale, :key, :options
 
@@ -63,8 +63,18 @@ module I18n
       end
 
       def message
-        "translation missing: #{keys.join('.')}"
+        if options[:default].is_a?(Array)
+          other_options = ([key, *options[:default]]).map { |k| normalized_option(k).prepend('- ') }.join("\n")
+          "Translation missing. Options considered were:\n#{other_options}"
+        else
+          "Translation missing: #{keys.join('.')}"
+        end
       end
+
+      def normalized_option(key)
+        I18n.normalize_keys(locale, key, options[:scope]).join('.')
+      end
+
       alias :to_s :message
 
       def to_exception

--- a/test/i18n/exceptions_test.rb
+++ b/test/i18n/exceptions_test.rb
@@ -32,6 +32,12 @@ class I18nExceptionsTest < I18n::TestCase
     end
   end
 
+  test "MissingTranslationData message contains all potential options" do
+    force_missing_translation_data(default: [:option_a, :option_b]) do |exception|
+      assert_equal "translation missing. Options considered were:\n- de.bar.option_a, \n- de.bar.option_a", exception.message
+    end
+  end
+
   test "InvalidPluralizationData stores entry, count and key" do
     force_invalid_pluralization_data do |exception|
       assert_equal({:other => "bar"}, exception.entry)


### PR DESCRIPTION
Hi,

This PR add more information to the error message for missing translation when a default option array was provided.

Example of error message:

```
I18n.t(
  :"role.name",
  scope: : "simple_form.placeholders",
  default: [:"defaults.new.name", :"defaults.name"], 
  raise: true)

Translation missing. Options considered were:
- en.simple_form.placeholders.role.new.name
- en.simple_form.placeholders.role.name
- en.simple_form.placeholders.defaults.new.name
- en.simple_form.placeholders.defaults.name

```