### PR TITLE
fix LazyLoadable#available_locales duplicating locales

### DIFF
--- a/lib/i18n/backend/lazy_loadable.rb
+++ b/lib/i18n/backend/lazy_loadable.rb
@@ -98,7 +98,7 @@ module I18n
       # Parse the load path and extract all locales.
       def available_locales
         if lazy_load?
-          I18n.load_path.map { |path| LocaleExtractor.locale_from_path(path) }
+          I18n.load_path.map { |path| LocaleExtractor.locale_from_path(path) }.uniq
         else
           super
         end

--- a/test/backend/lazy_loadable_test.rb
+++ b/test/backend/lazy_loadable_test.rb
@@ -7,7 +7,7 @@ class I18nBackendLazyLoadableTest < I18n::TestCase
     @lazy_mode_backend = I18n::Backend::LazyLoadable.new(lazy_load: true)
     @eager_mode_backend = I18n::Backend::LazyLoadable.new(lazy_load: false)
 
-    I18n.load_path = [File.join(locales_dir, '/en.yml'), File.join(locales_dir,  '/fr.yml')]
+    I18n.load_path = [File.join(locales_dir, '/en.yml'), File.join(locales_dir, '/en.yaml'), File.join(locales_dir,  '/fr.yml')]
   end
 
   test "lazy mode: only loads translations for current locale" do


### PR DESCRIPTION
Sometimes locales will be split across multiple files. LazyLoadable explicitly supports that, either by using multiple file types, or post-fixing the locale name with an _ and a descriptor.

But even so, there should only be one instance in available_locales.