### PR TITLE
Fix I18n.t when locale contains separator

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -332,9 +332,11 @@ module I18n
     def normalize_keys(locale, key, scope, separator = nil)
       separator ||= I18n.default_separator
 
-      result = locale ? normalize_key(locale, separator) : [locale]
-      result.concat(normalize_key(scope, separator)) if scope
-      result.concat(normalize_key(key, separator))
+      [
+        *normalize_key(locale, separator),
+        *normalize_key(scope, separator),
+        *normalize_key(key, separator)
+      ]
     end
 
     # Returns true when the passed locale, which can be either a String or a

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -331,9 +331,8 @@ module I18n
     # keys are Symbols.
     def normalize_keys(locale, key, scope, separator = nil)
       separator ||= I18n.default_separator
-      locale = locale.to_sym if locale
 
-      result = [locale]
+      result = locale ? normalize_key(locale, separator) : [locale]
       result.concat(normalize_key(scope, separator)) if scope
       result.concat(normalize_key(key, separator))
     end

--- a/lib/i18n/locale/fallbacks.rb
+++ b/lib/i18n/locale/fallbacks.rb
@@ -74,7 +74,6 @@ module I18n
               @map[from] << _to.to_sym
             end
           end
-          replace @map
         else
           @map.map(*args, &block)
         end

--- a/lib/i18n/tests/localization/date.rb
+++ b/lib/i18n/tests/localization/date.rb
@@ -64,7 +64,7 @@ module I18n
         end
 
         test "localize Date: given missing translations it returns the correct error message" do
-          assert_equal 'translation missing: fr.date.abbr_month_names', I18n.l(@date, :format => '%b', :locale => :fr)
+          assert_equal 'Translation missing: fr.date.abbr_month_names', I18n.l(@date, :format => '%b', :locale => :fr)
         end
 
         test "localize Date: given an unknown format it does not fail" do

--- a/lib/i18n/tests/localization/date_time.rb
+++ b/lib/i18n/tests/localization/date_time.rb
@@ -60,7 +60,7 @@ module I18n
         end
 
         test "localize DateTime: given missing translations it returns the correct error message" do
-          assert_equal 'translation missing: fr.date.abbr_month_names', I18n.l(@datetime, :format => '%b', :locale => :fr)
+          assert_equal 'Translation missing: fr.date.abbr_month_names', I18n.l(@datetime, :format => '%b', :locale => :fr)
         end
 
         test "localize DateTime: given a meridian indicator format it returns the correct meridian indicator" do

--- a/lib/i18n/tests/localization/time.rb
+++ b/lib/i18n/tests/localization/time.rb
@@ -61,7 +61,7 @@ module I18n
         end
 
         test "localize Time: given missing translations it returns the correct error message" do
-          assert_equal 'translation missing: fr.date.abbr_month_names', I18n.l(@time, :format => '%b', :locale => :fr)
+          assert_equal 'Translation missing: fr.date.abbr_month_names', I18n.l(@time, :format => '%b', :locale => :fr)
         end
 
         test "localize Time: given a meridian indicator format it returns the correct meridian indicator" do

--- a/lib/i18n/tests/lookup.rb
+++ b/lib/i18n/tests/lookup.rb
@@ -30,7 +30,7 @@ module I18n
       end
 
       test "lookup: given a missing key, no default and no raise option it returns an error message" do
-        assert_equal "translation missing: en.missing", I18n.t(:missing)
+        assert_equal "Translation missing: en.missing", I18n.t(:missing)
       end
 
       test "lookup: given a missing key, no default and the raise option it raises MissingTranslationData" do

--- a/test/backend/exceptions_test.rb
+++ b/test/backend/exceptions_test.rb
@@ -10,7 +10,7 @@ class I18nBackendExceptionsTest < I18n::TestCase
     exception = catch(:exception) do
       I18n.t(:'baz.missing', :scope => :'foo.bar', :throw => true)
     end
-    assert_equal "translation missing: en.foo.bar.baz.missing", exception.message
+    assert_equal "Translation missing: en.foo.bar.baz.missing", exception.message
   end
 
   test "exceptions: MissingTranslationData message from #translate includes the given scope and full key" do
@@ -18,7 +18,7 @@ class I18nBackendExceptionsTest < I18n::TestCase
       I18n.t(:'baz.missing', :scope => :'foo.bar', :raise => true)
     rescue I18n::MissingTranslationData => exception
     end
-    assert_equal "translation missing: en.foo.bar.baz.missing", exception.message
+    assert_equal "Translation missing: en.foo.bar.baz.missing", exception.message
   end
 
   test "exceptions: MissingTranslationData message from #localize includes the given scope and full key" do
@@ -26,7 +26,7 @@ class I18nBackendExceptionsTest < I18n::TestCase
       I18n.l(Time.now, :format => :foo)
     rescue I18n::MissingTranslationData => exception
     end
-    assert_equal "translation missing: en.time.formats.foo", exception.message
+    assert_equal "Translation missing: en.time.formats.foo", exception.message
   end
 
   test "exceptions: MissingInterpolationArgument message includes missing key, provided keys and full string" do

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -60,8 +60,14 @@ class I18nBackendFallbacksTranslateTest < I18n::TestCase
     assert_nil I18n.t(:missing_bar, :locale => :'de-DE', :default => nil)
   end
 
-  test "returns the translation missing message if the default is also missing" do
-    assert_equal 'translation missing: de-DE.missing_bar', I18n.t(:missing_bar, :locale => :'de-DE', :default => [:missing_baz])
+  test "returns the Translation missing: message if the default is also missing" do
+    translation_missing_message = <<~MSG
+      Translation missing. Options considered were:
+      - de-DE.missing_bar
+      - de-DE.missing_baz
+    MSG
+
+    assert_equal translation_missing_message.chomp, I18n.t(:missing_bar, :locale => :'de-DE', :default => [:missing_baz])
   end
 
   test "returns the :'de-DE' default :baz translation for a missing :'de-DE' when defaults contains Symbol" do

--- a/test/backend/key_value_test.rb
+++ b/test/backend/key_value_test.rb
@@ -21,7 +21,7 @@ class I18nBackendKeyValueTest < I18n::TestCase
     assert_flattens({:"a.b"=>['a', 'b']}, {:a=>{:b =>['a', 'b']}}, true, false)
     assert_flattens({:"a.b" => "c"}, {:"a.b" => "c"}, false)
   end
-  
+
   test "store_translations supports numeric keys" do
     setup_backend!
     store_translations(:en, 1 => 'foo')
@@ -60,8 +60,8 @@ class I18nBackendKeyValueTest < I18n::TestCase
     I18n.backend.send(:translations)
     expected = { :en => {:foo => { :bar => 'bar', :baz => 'baz' }} }
     assert_equal expected, translations
-  end 
-  
+  end
+
   test "subtrees enabled: given incomplete pluralization data it raises I18n::InvalidPluralizationData" do
     setup_backend!
     store_translations(:en, :bar => { :one => "One" })
@@ -71,7 +71,7 @@ class I18nBackendKeyValueTest < I18n::TestCase
   test "subtrees disabled: given incomplete pluralization data it returns an error message" do
     setup_backend!(false)
     store_translations(:en, :bar => { :one => "One" })
-    assert_equal "translation missing: en.bar", I18n.t(:bar, :count => 2)
+    assert_equal "Translation missing: en.bar", I18n.t(:bar, :count => 2)
   end
 
   test "translate handles subtrees for pluralization" do
@@ -79,7 +79,7 @@ class I18nBackendKeyValueTest < I18n::TestCase
     store_translations(:en, :bar => { :one => "One" })
     assert_equal("One", I18n.t("bar", :count => 1))
   end
-  
+
   test "subtrees enabled: returns localized string given missing pluralization data" do
     setup_backend!(true)
     assert_equal 'bar', I18n.t("foo.bar", count: 1)
@@ -89,7 +89,7 @@ class I18nBackendKeyValueTest < I18n::TestCase
     setup_backend!(false)
     assert_equal 'bar', I18n.t("foo.bar", count: 1)
   end
-  
+
   test "subtrees enabled: Returns fallback default given missing pluralization data" do
     setup_backend!(true)
     I18n.backend.extend I18n::Backend::Fallbacks

--- a/test/i18n/exceptions_test.rb
+++ b/test/i18n/exceptions_test.rb
@@ -32,12 +32,6 @@ class I18nExceptionsTest < I18n::TestCase
     end
   end
 
-  test "MissingTranslationData message contains all potential options" do
-    force_missing_translation_data(default: [:option_a, :option_b]) do |exception|
-      assert_equal "translation missing. Options considered were:\n- de.bar.option_a, \n- de.bar.option_a", exception.message
-    end
-  end
-
   test "InvalidPluralizationData stores entry, count and key" do
     force_invalid_pluralization_data do |exception|
       assert_equal({:other => "bar"}, exception.entry)

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -209,16 +209,16 @@ class I18nTest < I18n::TestCase
   end
 
   # def test_translate_given_no_args_raises_missing_translation_data
-  #   assert_equal "translation missing: en, no key", I18n.t
+  #   assert_equal "Translation missing: en, no key", I18n.t
   # end
 
   test "translate given a bogus key returns an error message" do
-    assert_equal "translation missing: en.bogus", I18n.t(:bogus)
+    assert_equal "Translation missing: en.bogus", I18n.t(:bogus)
   end
 
   test "translate given multiple bogus keys returns an array of error messages" do
     assert_equal(
-      ["translation missing: en.bogus", "translation missing: en.also_bogus"],
+      ["Translation missing: en.bogus", "Translation missing: en.also_bogus"],
       I18n.t([:bogus, :also_bogus]),
     )
   end
@@ -266,7 +266,7 @@ class I18nTest < I18n::TestCase
         I18n.t('foo')
       end
 
-      assert_equal 'translation missing: en.foo', I18n.t('foo', locale: :en)
+      assert_equal 'Translation missing: en.foo', I18n.t('foo', locale: :en)
     end
   end
 

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -140,6 +140,10 @@ class I18nTest < I18n::TestCase
     assert_equal [:en, :foo, :bar, :baz, :buz], I18n.normalize_keys(:en, :'baz|buz', :'foo|bar', '|')
   end
 
+  test "normalize_keys normalizes given locale with separator" do
+    assert_equal [:en, :foo, :bar, :baz], I18n.normalize_keys(:"en.foo", :baz, :bar)
+  end
+
   test "can set the exception_handler" do
     begin
       previous_exception_handler = I18n.exception_handler


### PR DESCRIPTION
[v1.13.0](https://github.com/ruby-i18n/i18n/pull/651/files#diff-d0c6e2735b6944fb4d9a02f844dcd785eec8cdcc1bec4da6f2ad6596e7b38551) broke a backward compatibility when locale contains separator, example:

```
# v1.12.0
require "i18n"

I18n.enforce_available_locales = false
I18n.backend.store_translations(:"en-api", v1: {foo: 'Foo in API'})
I18n.locale = :"en-api.v1"
I18n.t("foo")
# => "Foo in API"

# v1.13.0
require "i18n"

I18n.enforce_available_locales = false
I18n.backend.store_translations(:"en-api", v1: {foo: 'Foo in API'})
I18n.locale = :"en-api.v1"
I18n.t("foo")
# => "translation missing: en-api.v1.foo"
```

This PR brings back the separator separation for locale in `normalize_keys`.