### PR TITLE
Add documentation hint for fallback values

### DIFF
--- a/lib/i18n/backend/chain.rb
+++ b/lib/i18n/backend/chain.rb
@@ -16,6 +16,8 @@ module I18n
     #
     # The implementation assumes that all backends added to the Chain implement
     # a lookup method with the same API as Simple backend does.
+    # 
+    # Fallback translations using the :default option are only used by the last backend of a chain.
     class Chain
       module Implementation
         include Base


### PR DESCRIPTION
We had a minor issue in regards to default translation keys, hope this hint can help others.