### PR TITLE
Simplify the "Translation missing" message when default is an empty Array

### DIFF
--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -63,8 +63,8 @@ module I18n
       end
 
       def message
-        if options[:default].is_a?(Array)
-          other_options = ([key, *options[:default]]).map { |k| normalized_option(k).prepend('- ') }.join("\n")
+        if (default = options[:default]).is_a?(Array) && default.any?
+          other_options = ([key, *default]).map { |k| normalized_option(k).prepend('- ') }.join("\n")
           "Translation missing. Options considered were:\n#{other_options}"
         else
           "Translation missing: #{keys.join('.')}"

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -70,6 +70,10 @@ class I18nBackendFallbacksTranslateTest < I18n::TestCase
     assert_equal translation_missing_message.chomp, I18n.t(:missing_bar, :locale => :'de-DE', :default => [:missing_baz])
   end
 
+  test "returns the simple Translation missing: message when default is an empty Array" do
+    assert_equal "Translation missing: de-DE.missing_bar", I18n.t(:missing_bar, :locale => :'de-DE', :default => [])
+  end
+
   test "returns the :'de-DE' default :baz translation for a missing :'de-DE' when defaults contains Symbol" do
     assert_equal 'Baz in :de-DE', I18n.t(:missing_foo, :locale => :'de-DE', :default => [:baz, "Default Bar"])
   end


### PR DESCRIPTION
#654 changed the "Tranlation missing" message to show all the potential keys when an Array was given for `:default`, but this enhancement is not necessary if the `:default` Array was an empty Array.

Giving an empty Array for `:default` is actually done inside Action View translation helper: https://github.com/rails/rails/blob/254f1d8ded07dfd73462b40d6aaa8c19032259f6/actionview/lib/action_view/helpers/translation_helper.rb#L125
and so this causes this build error there in Rails repo. https://buildkite.com/rails/rails/builds/96893#01887b39-855d-4c78-a6ac-0c90889025fd