### PR TITLE
A fix for failing CI against edge Rails

### DIFF
--- a/test/backend/cache_test.rb
+++ b/test/backend/cache_test.rb
@@ -62,8 +62,9 @@ class I18nBackendCacheTest < I18n::TestCase
     I18n.t(:missing, :scope => :foo, :extra => true)
     assert_equal 1, I18n.cache_store.instance_variable_get(:@data).size
 
-    _, entry = I18n.cache_store.instance_variable_get(:@data).first
-    assert_equal({ scope: :foo }, entry.value.options)
+    value = I18n.cache_store.read(I18n.cache_store.instance_variable_get(:@data).keys.first)
+
+    assert_equal({ scope: :foo }, value.options)
   end
 
   test "uses 'i18n' as a cache key namespace by default" do


### PR DESCRIPTION
Here's a fix for the edge Rails CI failure.

There's a test code directly accessing a cached instance variable inside Active Support MemoryStore object, but since Rails 7.1 changed its implementation to hold the `@data` ivar as a marshalled String, the test now fails on edge Rails.

This patch fixes the failure by properly calling publicly accessible API.