### PR TITLE
Skip CIing on jruby against Rails 5.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,6 +42,10 @@ jobs:
           - ruby_version: 2.6
             gemfile: gemfiles/Gemfile.rails-7.0.x
 
+          # JRuby 9.4.2.0 (3.1.0) is not supported by Rails 5.2.x
+          - ruby_version: jruby
+            gemfile: gemfiles/Gemfile.rails-5.2.x
+
           # JRuby is not supported by Rails 7.0.x
           - ruby_version: jruby
             gemfile: gemfiles/Gemfile.rails-7.0.x


### PR DESCRIPTION
JRuby 9.4.2.0 is equivalent to CRuby 3.1.0 which is not supported by Rails 5.2.x.

This patch together with #663 should bring back the CI to be 🟢 