### PR TITLE
Fix build warnings in the CI by using actions/checkout@v3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This addresses the following warnings.

"Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2." https://github.com/ruby-i18n/i18n/actions/runs/5161186483