### PR TITLE
Regex part deux - INTERPOLATION_SYNTAX

### DIFF
--- a/lib/i18n/backend/interpolation_compiler.rb
+++ b/lib/i18n/backend/interpolation_compiler.rb
@@ -21,7 +21,7 @@ module I18n
       module Compiler
         extend self
 
-        TOKENIZER                    = /(%%\{[^\}]+\}|%\{[^\}]+\})/
+        TOKENIZER                    = /(%%?\{[^}]+\})/
         INTERPOLATION_SYNTAX_PATTERN = /(%)?(%\{([^\}]+)\})/
 
         def compile_if_an_interpolation(string)

--- a/lib/i18n/backend/interpolation_compiler.rb
+++ b/lib/i18n/backend/interpolation_compiler.rb
@@ -22,7 +22,7 @@ module I18n
         extend self
 
         TOKENIZER                    = /(%%?\{[^}]+\})/
-        INTERPOLATION_SYNTAX_PATTERN = /(%)?(%\{([^\}]+)\})/
+        INTERPOLATION_SYNTAX_PATTERN = /(%%?)\{([^}]+)\}/
 
         def compile_if_an_interpolation(string)
           if interpolated_str?(string)
@@ -53,8 +53,8 @@ module I18n
         end
 
         def handle_interpolation_token(interpolation, matchdata)
-          escaped, pattern, key = matchdata.values_at(1, 2, 3)
-          escaped ? pattern : compile_interpolation_token(key.to_sym)
+          escaped, key = matchdata.values_at(1, 2)
+          escaped == '%%' ? "%{#{key}}" : compile_interpolation_token(key.to_sym)
         end
 
         def compile_interpolation_token(key)

--- a/lib/i18n/backend/interpolation_compiler.rb
+++ b/lib/i18n/backend/interpolation_compiler.rb
@@ -21,8 +21,7 @@ module I18n
       module Compiler
         extend self
 
-        TOKENIZER                    = /(%%?\{[^}]+\})/
-        INTERPOLATION_SYNTAX_PATTERN = /(%%?)\{([^}]+)\}/
+        TOKENIZER = /(%%?\{[^}]+\})/
 
         def compile_if_an_interpolation(string)
           if interpolated_str?(string)
@@ -37,7 +36,7 @@ module I18n
         end
 
         def interpolated_str?(str)
-          str.kind_of?(::String) && str =~ INTERPOLATION_SYNTAX_PATTERN
+          str.kind_of?(::String) && str =~ TOKENIZER
         end
 
         protected
@@ -48,13 +47,12 @@ module I18n
 
         def compiled_interpolation_body(str)
           tokenize(str).map do |token|
-            (matchdata = token.match(INTERPOLATION_SYNTAX_PATTERN)) ? handle_interpolation_token(token, matchdata) : escape_plain_str(token)
+            token.match(TOKENIZER) ? handle_interpolation_token(token) : escape_plain_str(token)
           end.join
         end
 
-        def handle_interpolation_token(interpolation, matchdata)
-          escaped, key = matchdata.values_at(1, 2)
-          escaped == '%%' ? "%{#{key}}" : compile_interpolation_token(key.to_sym)
+        def handle_interpolation_token(token)
+          token.start_with?('%%') ? token[1..] : compile_interpolation_token(token[2..-2])
         end
 
         def compile_interpolation_token(key)


### PR DESCRIPTION
Thanks for the great gem.

I was curious what I could do with `INTERPOLATION_SYNTAX`.

This has 3 commits.

- The commit from the regex #668
- An update to `INTERPOLATION_SYNTAX` with minor ruby changes.
- Dropping `INTERPOLATION_SYNTAX` and just using `TOKENIZER`.

I ran tests with ruby 2.6.9 and 3.0.6

Not sure when the syntax change for the substring was introduced `str[1..]`.
rubocop suggested I change my `str[1..-1]` over to that.
They also said the backslash in `[^\}]` was not necessary.

Let me know if you would like to keep `INTERPOLATION_SYNTAX` and I can throw away the second commit. Or if you like it, I can squash the two.
Something was nice about the multiple capture groups in the regular expression, but I didn't feel the complexity (from pcre's perspective) bought too much. But since this is your project, it is your call.


Also in reference to #667 

As I started to run numbers, I'm feeling less and less like this is a DoS. So maybe I'm not the right person to state an opinion on whether these changes are necessary.

### From the commit messages

```ruby

/(%)?(%\{([^\}]+)\})/ =~ '%{{'*9999)+'}'

/(%)?(%\{([^\}]+)\})/ ==> 199,984 steps
/(%%?)\{([^\}]+)\}/   ==> 129,989 steps

/(%%?\{[^\}]+\})/     ==>  99,992 steps
```

But that hasn't reached the `TOKENIZER` performance, so the second commit went with that one:

```ruby
/(%%?\{[^\}]+\})/     ==>  99,992 steps
```