### PR TITLE
Update `mocha` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'mocha', '~> 1.7.0'
+gem 'mocha', '~> 2.1.0'
 gem 'test_declarative', '0.0.6'
 gem 'rake', '~> 13'
 gem 'minitest', '~> 5.14'

--- a/gemfiles/Gemfile.rails-5.0.x
+++ b/gemfiles/Gemfile.rails-5.0.x
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', '~> 5.0.0'
-gem 'mocha', '~> 1.7.0'
+gem 'mocha', '~> 2.1.0'
 gem 'test_declarative', '0.0.6'
 gem 'rake', '~> 13'
 gem 'minitest', '~> 5.14'

--- a/gemfiles/Gemfile.rails-5.1.x
+++ b/gemfiles/Gemfile.rails-5.1.x
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', '~> 5.1.0'
-gem 'mocha', '~> 1.7.0'
+gem 'mocha', '~> 2.1.0'
 gem 'test_declarative', '0.0.6'
 gem 'rake'
 gem 'minitest', '~> 5.14'

--- a/gemfiles/Gemfile.rails-5.2.x
+++ b/gemfiles/Gemfile.rails-5.2.x
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', '~> 5.2.0'
-gem 'mocha', '~> 1.7.0'
+gem 'mocha', '~> 2.1.0'
 gem 'test_declarative', '0.0.6'
 gem 'rake'
 gem 'minitest', '~> 5.14'

--- a/gemfiles/Gemfile.rails-6.0.x
+++ b/gemfiles/Gemfile.rails-6.0.x
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', '~> 6.0.0'
-gem 'mocha', '~> 1.7.0'
+gem 'mocha', '~> 2.1.0'
 gem 'test_declarative', '0.0.6'
 gem 'rake'
 gem 'minitest', '~> 5.14'

--- a/gemfiles/Gemfile.rails-6.1.x
+++ b/gemfiles/Gemfile.rails-6.1.x
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', '~> 6.1'
-gem 'mocha', '~> 1.7.0'
+gem 'mocha', '~> 2.1.0'
 gem 'test_declarative', '0.0.6'
 gem 'rake'
 gem 'minitest', '~> 5.14'

--- a/gemfiles/Gemfile.rails-7.0.x
+++ b/gemfiles/Gemfile.rails-7.0.x
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', '~> 7.0'
-gem 'mocha', '~> 1.7.0'
+gem 'mocha', '~> 2.1.0'
 gem 'test_declarative', '0.0.6'
 gem 'rake'
 gem 'minitest', '~> 5.14'

--- a/gemfiles/Gemfile.rails-main
+++ b/gemfiles/Gemfile.rails-main
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', github: 'rails/rails', branch: 'main'
-gem 'mocha', '~> 1.7.0'
+gem 'mocha', '~> 2.1.0'
 gem 'test_declarative', '0.0.6'
 gem 'rake'
 gem 'minitest', '~> 5.1'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require 'bundler/setup'
 require 'i18n'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'test_declarative'
 
 class I18n::TestCase < Minitest::Test


### PR DESCRIPTION
Currently, when trying to run the tests locally, I get
```
/Users/fatkodima/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/mocha-1.7.0/lib/mocha/integration/mini_test/adapter.rb:26:in `included': uninitialized constant MiniTest (NameError)

          Mocha::ExpectationErrorFactory.exception_class = ::MiniTest::Assertion
                                                                     ^^^^^^^^^^^
Did you mean?  Minitest
```