### PR TITLE
Raise when translated entry contains interpolations for reserved keywords and no substitutions provided

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -55,12 +55,14 @@ module I18n
 
         deep_interpolation = options[:deep_interpolation]
         values = Utils.except(options, *RESERVED_KEYS) unless options.empty?
-        if values
+        if values && !values.empty?
           entry = if deep_interpolation
             deep_interpolate(locale, entry, values)
           else
             interpolate(locale, entry, values)
           end
+        elsif entry.is_a?(String) && entry =~ I18n.reserved_keys_pattern
+          raise ReservedInterpolationKey.new($1.to_sym, entry)
         end
         entry
       end

--- a/lib/i18n/tests/interpolation.rb
+++ b/lib/i18n/tests/interpolation.rb
@@ -112,6 +112,10 @@ module I18n
         assert_raises(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{default}') }
         assert_raises(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{separator}') }
         assert_raises(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{scope}') }
+        assert_raises(I18n::ReservedInterpolationKey) { interpolate(:default => '%{scope}') }
+
+        I18n.backend.store_translations(:en, :interpolate => 'Hi %{scope}!')
+        assert_raises(I18n::ReservedInterpolationKey) { interpolate(:interpolate) }
       end
 
       test "interpolation: deep interpolation for default string" do


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/49879.