### PR TITLE
Add racc to gemspec

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: [3.2, 3.1, "3.0", 2.7, 2.6, jruby]
+        ruby_version: [3.3, 3.2, 3.1, "3.0", 2.7, 2.6, jruby]
         gemfile:
           - Gemfile
           - gemfiles/Gemfile.rails-5.2.x

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,6 +26,10 @@ jobs:
           - gemfiles/Gemfile.rails-7.0.x
           - gemfiles/Gemfile.rails-main
         exclude:
+          # Ruby 3.3 is not supported by Rails 5.2.x
+          - ruby_version: 3.3
+            gemfile: gemfiles/Gemfile.rails-5.2.x
+
           # Ruby 3.2 is not supported by Rails 5.2.x
           - ruby_version: 3.2
             gemfile: gemfiles/Gemfile.rails-5.2.x
@@ -37,6 +41,14 @@ jobs:
           # Ruby 3.x is not supported by Rails 5.2.x
           - ruby_version: "3.0"
             gemfile: gemfiles/Gemfile.rails-5.2.x
+
+          # Ruby 3.0.x is not supported by Rails main
+          - ruby_version: "3.0"
+            gemfile: gemfiles/Gemfile.rails-main
+
+          # Ruby 2.7.x is not supported by Rails main
+          - ruby_version: 2.7
+            gemfile: gemfiles/Gemfile.rails-main
 
           # Ruby 2.6.x is not supported by Rails main
           - ruby_version: 2.6

--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.5'
   s.required_ruby_version = '>= 2.3.0'
 
+  s.add_dependency 'racc'
   s.add_dependency 'concurrent-ruby', '~> 1.0'
 
 end


### PR DESCRIPTION
According the [release note of Ruby 3.3](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/), racc will become the bundled gem. This patch adds the gem to i18n.gemspec for the next version of Ruby.

In addition to this change, I made changes in the GitHub workflow to run tests in Ruby 3.3 because I got an error in Ruby 3.3 when running tests: `cannot load such file -- racc/parser`. This error is resolved by adding racc to gemspec.

I want to make sure this Gem works in Ruby 3.3, so the GitHub workflow is also updated.

<details><summary>The backtrace for cannot load such file -- racc/parser</summary>
<p>

```
/Users/yutaka.kamei/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require': cannot load such file -- racc/parser (LoadError)
	from /Users/yutaka.kamei/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /Users/yutaka.kamei/git/Fork/i18n/lib/i18n/gettext/po_parser.rb:13:in `<top (required)>'
	from /Users/yutaka.kamei/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /Users/yutaka.kamei/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /Users/yutaka.kamei/git/Fork/i18n/lib/i18n/backend/gettext.rb:4:in `<top (required)>'
	from /Users/yutaka.kamei/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /Users/yutaka.kamei/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /Users/yutaka.kamei/git/Fork/i18n/test/gettext/backend_test.rb:9:in `<class:Backend>'
	from /Users/yutaka.kamei/git/Fork/i18n/test/gettext/backend_test.rb:8:in `<class:I18nGettextBackendTest>'
	from /Users/yutaka.kamei/git/Fork/i18n/test/gettext/backend_test.rb:5:in `<top (required)>'
	from /Users/yutaka.kamei/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /Users/yutaka.kamei/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /Users/yutaka.kamei/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /Users/yutaka.kamei/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `select'
	from /Users/yutaka.kamei/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
```

</p>
</details> 