### PR TITLE
Add I18n.interpolation_keys

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -233,18 +233,23 @@ module I18n
 
     # Returns an array of interpolation keys for the given translation key
     #
+    # *Examples*
+    #
     # Suppose we have the following:
     #   I18n.t 'example.zero' == 'Zero interpolations'
     #   I18n.t 'example.one' == 'One interpolation %{foo}'
     #   I18n.t 'example.two' == 'Two interpolations %{foo} %{bar}'
+    #   I18n.t 'example.three' == ['One %{foo}', 'Two %{bar}', 'Three %{baz}']
     #   I18n.t 'example.one', locale: :other == 'One interpolation %{baz} %{bar}'
     #
     # Then we can expect the following results:
     #   I18n.interpolation_keys('example.zero') #=> []
     #   I18n.interpolation_keys('example.one') #=> ['foo']
     #   I18n.interpolation_keys('example.two') #=> ['foo', 'bar']
+    #   I18n.interpolation_keys('example.three') #=> ['foo', 'bar', 'baz']
     #   I18n.interpolation_keys('one', scope: 'example', locale: :other) #=> ['baz']
     #   I18n.interpolation_keys('does-not-exist') #=> []
+    #   I18n.interpolation_keys('example') #=> []
     def interpolation_keys(key, **options)
       raise I18n::ArgumentError if !key.is_a?(String) || key.empty?
 

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -251,12 +251,8 @@ module I18n
       return [] unless exists?(key, **options.slice(:locale, :scope))
 
       translation = translate(key, **options.slice(:locale, :scope))
-
-      raise I18n::NonStringTranslationError unless translation.is_a?(String)
-      translation
-        .scan(Regexp.union(I18n.config.interpolation_patterns))
-        .flatten
-        .compact
+      interpolation_keys_from_translation(translation)
+        .flatten.compact
     end
 
     # Returns true if a translation exists for a given key, otherwise returns false.
@@ -456,6 +452,17 @@ module I18n
           end
           keys
         end
+    end
+
+    def interpolation_keys_from_translation(translation)
+      case translation
+      when ::String
+        translation.scan(Regexp.union(I18n.config.interpolation_patterns))
+      when ::Array
+        translation.map { |element| interpolation_keys_from_translation(element) }
+      else
+        []
+      end
     end
   end
 

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -250,7 +250,10 @@ module I18n
 
       return [] unless exists?(key, **options.slice(:locale, :scope))
 
-      translate(key, **options.slice(:locale, :scope))
+      translation = translate(key, **options.slice(:locale, :scope))
+
+      raise I18n::NonStringTranslationError unless translation.is_a?(String)
+      translation
         .scan(Regexp.union(I18n.config.interpolation_patterns))
         .flatten
         .compact

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -231,6 +231,31 @@ module I18n
     end
     alias :t! :translate!
 
+    # Returns an array of interpolation keys for the given translation key
+    #
+    # Suppose we have the following:
+    #   I18n.t 'example.zero' == 'Zero interpolations'
+    #   I18n.t 'example.one' == 'One interpolation %{foo}'
+    #   I18n.t 'example.two' == 'Two interpolations %{foo} %{bar}'
+    #   I18n.t 'example.one', locale: :other == 'One interpolation %{baz} %{bar}'
+    #
+    # Then we can expect the following results:
+    #   I18n.interpolation_keys('example.zero') #=> []
+    #   I18n.interpolation_keys('example.one') #=> ['foo']
+    #   I18n.interpolation_keys('example.two') #=> ['foo', 'bar']
+    #   I18n.interpolation_keys('one', scope: 'example', locale: :other) #=> ['baz']
+    #   I18n.interpolation_keys('does-not-exist') #=> []
+    def interpolation_keys(key, **options)
+      raise I18n::ArgumentError if !key.is_a?(String) || key.empty?
+
+      return [] unless exists?(key, **options.slice(:locale, :scope))
+
+      translate(key, **options.slice(:locale, :scope))
+        .scan(Regexp.union(I18n.config.interpolation_patterns))
+        .flatten
+        .compact
+    end
+
     # Returns true if a translation exists for a given key, otherwise returns false.
     def exists?(key, _locale = nil, locale: _locale, **options)
       locale ||= config.locale

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -240,7 +240,7 @@ module I18n
     #   I18n.t 'example.one' == 'One interpolation %{foo}'
     #   I18n.t 'example.two' == 'Two interpolations %{foo} %{bar}'
     #   I18n.t 'example.three' == ['One %{foo}', 'Two %{bar}', 'Three %{baz}']
-    #   I18n.t 'example.one', locale: :other == 'One interpolation %{baz} %{bar}'
+    #   I18n.t 'example.one', locale: :other == 'One interpolation %{baz}'
     #
     # Then we can expect the following results:
     #   I18n.interpolation_keys('example.zero') #=> []

--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -154,4 +154,6 @@ module I18n
       MSG
     end
   end
+
+  class NonStringTranslationError < ArgumentError; end
 end

--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -154,6 +154,4 @@ module I18n
       MSG
     end
   end
-
-  class NonStringTranslationError < ArgumentError; end
 end

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -287,6 +287,29 @@ class I18nTest < I18n::TestCase
     assert_equal I18n.config.available_locales.size * 2, I18n.config.available_locales_set.size
   end
 
+  test "interpolation_keys returns an array of keys" do
+    store_translations(:en, "example_two" => "Two interpolations %{foo} %{bar}")
+    assert_equal ["foo", "bar"], I18n.interpolation_keys("example_two")
+  end
+
+  test "interpolation_keys returns an empty array when no interpolations " do
+    store_translations(:en, "example_zero" => "Zero interpolations")
+    assert_equal [], I18n.interpolation_keys("example_zero")
+  end
+
+  test "interpolation_keys returns an empty array when missing translation " do
+    assert_equal [], I18n.interpolation_keys("does-not-exist")
+  end
+
+  test "interpolation_keys raises I18n::ArgumentError when non-string argument" do
+    assert_raises(I18n::ArgumentError) { I18n.interpolation_keys(["bad-argument"]) }
+  end
+
+  test "interpolation_keys raises I18n::NonStringTranslationError when translation is not a String" do
+    store_translations(:en, "example_nested" => { "one" => "One", "two" => "Two" })
+    assert_raises(I18n::NonStringTranslationError) { I18n.interpolation_keys("example_nested") }
+  end
+
   test "exists? given an existing key will return true" do
     assert_equal true, I18n.exists?(:currency)
   end

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -301,13 +301,18 @@ class I18nTest < I18n::TestCase
     assert_equal [], I18n.interpolation_keys("does-not-exist")
   end
 
-  test "interpolation_keys raises I18n::ArgumentError when non-string argument" do
-    assert_raises(I18n::ArgumentError) { I18n.interpolation_keys(["bad-argument"]) }
+  test "interpolation_keys returns an empty array when nested translation" do
+    store_translations(:en, "example_nested" => { "one" => "One %{foo}", "two" => "Two %{bar}" })
+    assert_equal [], I18n.interpolation_keys("example_nested")
   end
 
-  test "interpolation_keys raises I18n::NonStringTranslationError when translation is not a String" do
-    store_translations(:en, "example_nested" => { "one" => "One", "two" => "Two" })
-    assert_raises(I18n::NonStringTranslationError) { I18n.interpolation_keys("example_nested") }
+  test "interpolation_keys returns an array of keys when translation is an Array" do
+    store_translations(:en, "example_array" => ["One %{foo}", ["Two %{bar}", ["Three %{baz}"]]])
+    assert_equal ["foo", "bar", "baz"], I18n.interpolation_keys("example_array")
+  end
+
+  test "interpolation_keys raises I18n::ArgumentError when non-string argument" do
+    assert_raises(I18n::ArgumentError) { I18n.interpolation_keys(["bad-argument"]) }
   end
 
   test "exists? given an existing key will return true" do


### PR DESCRIPTION
Adds a **new method**, `I18n.interpolation_keys`, which returns a list of keys needed to fully resolve a translation.

Some examples:

```
    # Suppose we have the following:
    #   I18n.t 'example.zero' == 'Zero interpolations'
    #   I18n.t 'example.one' == 'One interpolation %{foo}'
    #   I18n.t 'example.two' == 'Two interpolations %{foo} %{bar}'
    #   I18n.t 'example.three' == ['One %{foo}', 'Two %{bar}', 'Three %{baz}']
    #   I18n.t 'example.one', locale: :other == 'One interpolation %{baz}'
    #
    # Then we can expect the following results:
    #   I18n.interpolation_keys('example.zero') #=> []
    #   I18n.interpolation_keys('example.one') #=> ['foo']
    #   I18n.interpolation_keys('example.two') #=> ['foo', 'bar']
    #   I18n.interpolation_keys('example.three') #=> ['foo', 'bar', 'baz']
    #   I18n.interpolation_keys('one', scope: 'example', locale: :other) #=> ['baz']
    #   I18n.interpolation_keys('does-not-exist') #=> []
    #   I18n.interpolation_keys('example') #=> []
```

---

In a recent project, I wanted to be able to figure out "What keys are needed for this translation"?
To my surprise, there wasn't a built-in method for this in `I18n`; the only option was to hand-roll some regex to look for `%{...}` patterns in the translation.

So now I've tried to implement it here "properly", making use of `I18n.config.interpolation_patterns` to be more robust with how interpolations are identified by the library -- e.g. it will also [match `%<foo>.d` by default](https://github.com/ruby-i18n/i18n/blob/74258ad03021c3592302438b86e08ab778e85007/lib/i18n/interpolate/ruby.rb#L10), and respect [custom pattern configurations like `{{foo}}`](https://github.com/ruby-i18n/i18n/blob/74258ad03021c3592302438b86e08ab778e85007/test/i18n/interpolate_test.rb#L103).