### PR TITLE
undo strict racc dependency on this branch

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,10 +26,12 @@ jobs:
           - gemfiles/Gemfile.rails-7.1.x
           - gemfiles/Gemfile.rails-main
         exclude:
+          # Ruby 3.0 is not supported by Rails main (requires at least Ruby 3.1)
+          - ruby_version: '3.0'
+            gemfile: gemfiles/Gemfile.rails-main
           # JRuby is not supported by Rails 7.0.x
           - ruby_version: jruby
             gemfile: gemfiles/Gemfile.rails-7.0.x
-
           # JRuby is not supported by Rails main
           - ruby_version: jruby
             gemfile: gemfiles/Gemfile.rails-main

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: [3.3, 3.2, 3.1, 3.0, jruby]
+        ruby_version: [3.3, 3.2, 3.1, '3.0', jruby]
         gemfile:
           - Gemfile
           - gemfiles/Gemfile.rails-6.0.x

--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -27,6 +27,4 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3.0'
 
   s.add_dependency 'concurrent-ruby', '~> 1.0'
-  s.add_dependency 'racc', '~> 1.7'
-
 end


### PR DESCRIPTION
This causes people's builds to break.

See #685 for the discussion.

Yes, this means i18n will not install on Ruby 3.3 until you also install the Racc gem.

This will be addressed in an upcoming 2.x release for i18n.