### PR TITLE
Fix that escaped interpolations with reserved keywords raised ReservedInterpolationKey

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -48,7 +48,7 @@ module I18n
   end
 
   def self.reserved_keys_pattern # :nodoc:
-    @reserved_keys_pattern ||= /%\{(#{RESERVED_KEYS.join("|")})\}/
+    @reserved_keys_pattern ||= /(?<!%)%\{(#{RESERVED_KEYS.join("|")})\}/
   end
 
   module Base

--- a/lib/i18n/tests/interpolation.rb
+++ b/lib/i18n/tests/interpolation.rb
@@ -118,6 +118,21 @@ module I18n
         assert_raises(I18n::ReservedInterpolationKey) { interpolate(:interpolate) }
       end
 
+      test "interpolation: it does not raise I18n::ReservedInterpolationKey for escaped variables" do
+        assert_nothing_raised do
+          assert_equal '%{separator}', interpolate(:foo => :bar, :default => '%%{separator}')
+        end
+
+        assert_nothing_raised do
+          assert_equal '%%{scope}', interpolate(:default => '%%{scope}')
+        end
+
+        I18n.backend.store_translations(:en, :interpolate => 'Hi %%{scope}!')
+        assert_nothing_raised do
+          assert_equal 'Hi %%{scope}!', interpolate(:interpolate)
+        end
+      end
+
       test "interpolation: deep interpolation for default string" do
         assert_equal 'Hi %{name}!', interpolate(:default => 'Hi %{name}!', :deep_interpolation => true)
       end

--- a/lib/i18n/tests/interpolation.rb
+++ b/lib/i18n/tests/interpolation.rb
@@ -123,6 +123,9 @@ module I18n
           assert_equal '%{separator}', interpolate(:foo => :bar, :default => '%%{separator}')
         end
 
+        # Note: The two interpolations below do not remove the escape character (%) because
+        #   I18n should not alter the strings when no interpolation parameters are given,
+        #   see the comment at the top of this file.
         assert_nothing_raised do
           assert_equal '%%{scope}', interpolate(:default => '%%{scope}')
         end


### PR DESCRIPTION
I found this issue when looking into fixing https://github.com/glebm/i18n-tasks/issues/552. The reserved keywords in the interpolations were noticed due to #678. The [proposed solution](https://github.com/glebm/i18n-tasks/issues/552#issuecomment-1984282062) is to escape the interpolation with `%%` based on https://github.com/ruby-i18n/i18n/blob/master/lib/i18n/interpolate/ruby.rb.

However, the check for reserved keywords didn't care that the interpolation was escaped. I adjusted the regex for the reserved keywords with the same negative lookbehind assertion as proposed in the i18n-tasks issue.