### PR TITLE
fix issues with RDoc generation

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -161,7 +161,7 @@ module I18n
     # or <tt>default</tt> if no translations for <tt>:foo</tt> and <tt>:bar</tt> were found.
     #   I18n.t :foo, :default => [:bar, 'default']
     #
-    # *BULK LOOKUP*
+    # <b>BULK LOOKUP</b>
     #
     # This returns an array with the translations for <tt>:foo</tt> and <tt>:bar</tt>.
     #   I18n.t [:foo, :bar]
@@ -180,7 +180,7 @@ module I18n
     # E.g. assuming the key <tt>:salutation</tt> resolves to:
     #   lambda { |key, options| options[:gender] == 'm' ? "Mr. #{options[:name]}" : "Mrs. #{options[:name]}" }
     #
-    # Then <tt>I18n.t(:salutation, :gender => 'w', :name => 'Smith') will result in "Mrs. Smith".
+    # Then <tt>I18n.t(:salutation, :gender => 'w', :name => 'Smith')</tt> will result in "Mrs. Smith".
     #
     # Note that the string returned by lambda will go through string interpolation too,
     # so the following lambda would give the same result:
@@ -192,7 +192,7 @@ module I18n
     # always return the same translations/values per unique combination of argument
     # values.
     #
-    # *Ruby 2.7+ keyword arguments warning*
+    # <b>Ruby 2.7+ keyword arguments warning</b>
     #
     # This method uses keyword arguments.
     # There is a breaking change in ruby that produces warning with ruby 2.7 and won't work as expected with ruby 3.0

--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -10,14 +10,14 @@ module I18n
     # The implementation is provided by a Implementation module allowing to easily
     # extend Simple backend's behavior by including modules. E.g.:
     #
-    # module I18n::Backend::Pluralization
-    #   def pluralize(*args)
-    #     # extended pluralization logic
-    #     super
-    #   end
-    # end
-    #
-    # I18n::Backend::Simple.include(I18n::Backend::Pluralization)
+    #     module I18n::Backend::Pluralization
+    #       def pluralize(*args)
+    #         # extended pluralization logic
+    #         super
+    #       end
+    #     end
+    #     
+    #     I18n::Backend::Simple.include(I18n::Backend::Pluralization)
     class Simple
       module Implementation
         include Base


### PR DESCRIPTION
Reading the RDoc and noticed a few things weren't generating correctly.

* RDoc supports \* to bold something, but only at the word level. For more than one word, you have to use `<b>` tags
* There was a dangling `<tt>` unclosed
* For inline code, the code must be indented or it won't format as code