### PR TITLE
Fix loading of .rb locale files when `load_path` is not a string

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -244,7 +244,7 @@ module I18n
         # Loads a plain Ruby translations file. eval'ing the file must yield
         # a Hash containing translation data with locales as toplevel keys.
         def load_rb(filename)
-          translations = eval(IO.read(filename), binding, filename)
+          translations = eval(IO.read(filename), binding, filename.to_s)
           [translations, false]
         end
 

--- a/test/i18n/load_path_test.rb
+++ b/test/i18n/load_path_test.rb
@@ -31,4 +31,14 @@ class I18nLoadPathTest < I18n::TestCase
     I18n.load_path << Dir[locales_dir + '/*.{rb,yml}']
     assert_equal "baz", I18n.t(:'foo.bar')
   end
+
+  test "adding Pathnames to the load path does not break YML file locale loading" do
+    I18n.load_path << Pathname.new(locales_dir + '/en.yml')
+    assert_equal "baz", I18n.t(:'foo.bar')
+  end
+
+  test "adding Pathnames to the load path does not break Ruby file locale loading" do
+    I18n.load_path << Pathname.new(locales_dir + '/en.rb')
+    assert_equal "bas", I18n.t(:'fuh.bah')
+  end
 end


### PR DESCRIPTION
Fixes #700 

When `load_path` contains `Pathname` objects this is usually fine as things like `File.open` take them, however the one place is breaks is loading `.rb` locale files due to the 3rd param of `Kernel#eval` seemingly [needing to be a String](https://github.com/ruby/ruby/blob/1b8fb4860bebe077bdf24bfb1b0218fba959446e/vm_eval.c#L1821).

This fixes the issue by calling `.to_s` on the `filename` object before calling `eval`

