### PR TITLE
Only require 'other' plural subkey for locales where pluralization rules are undefined

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -173,11 +173,12 @@ module I18n
 
         # Picks a translation from a pluralized mnemonic subkey according to English
         # pluralization rules :
-        # - It will pick the :one subkey if count is equal to 1.
+        # - It will pick the :zero subkey where count is equal to 0 and there
+        #   is a :zero subkey present. This behaviour is not standard with
+        #   regards to the CLDR pluralization rules.
+        # - It will pick the :one subkey if count is equal to 1 and there is a
+        #   :one subkey present.
         # - It will pick the :other subkey otherwise.
-        # - It will pick the :zero subkey in the special case where count is
-        #   equal to 0 and there is a :zero subkey present. This behaviour is
-        #   not standard with regards to the CLDR pluralization rules.
         # Other backends can implement more flexible or complex pluralization rules.
         def pluralize(locale, entry, count)
           entry = entry.reject { |k, _v| k == :attributes } if entry.is_a?(Hash)
@@ -306,8 +307,9 @@ module I18n
         end
 
         def pluralization_key(entry, count)
-          key = :zero if count == 0 && entry.has_key?(:zero)
-          key ||= count == 1 ? :one : :other
+          return :zero if count == 0 && entry.has_key?(:zero)
+          return :one if count == 1 && entry.has_key?(:one)
+          :other
         end
     end
   end

--- a/test/backend/pluralization_test.rb
+++ b/test/backend/pluralization_test.rb
@@ -92,4 +92,15 @@ class I18nBackendPluralizationTest < I18n::TestCase
     assert_equal "I have 1 Porsche 🚗", I18n.t(:'automobiles.porsche', count: 1, :locale => :xx)
     assert_equal "I have 20 Porsches 🚗", I18n.t(:'automobiles.porsche', count: 20, :locale => :xx)
   end
+
+  test "only 'other' is required on a locale without pluralization rules" do
+    store_translations(:no_plural_rule_locale,
+                       :stars => {
+                         other: "%{count} stars",
+                       }
+    )
+    assert_equal "0 stars", I18n.t('stars', count: 0, :locale => :no_plural_rule_locale)
+    assert_equal "1 stars", I18n.t('stars', count: 1, :locale => :no_plural_rule_locale)
+    assert_equal "20 stars", I18n.t('stars', count: 20, :locale => :no_plural_rule_locale)
+  end
 end


### PR DESCRIPTION
Previously, the 'one' and 'other' subkeys were both required, with the 'zero' subkey being optionally used. This failed for some languages that do not have a 'one' form. All languages have an 'other' form, so make that the only subkey that's required, and turn 'one' into an optional subkey just like 'zero'.

Fixes #706