### PR TITLE
Explicitly require `pathname`

### DIFF
--- a/test/i18n/load_path_test.rb
+++ b/test/i18n/load_path_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'pathname'
 
 class I18nLoadPathTest < I18n::TestCase
   def setup


### PR DESCRIPTION
Bundler requires `pathname`, therefore it might not always be needed. But it is right thing to not rely on Bundler internals.