### PR TITLE
Remove unused `cgi` require for Ruby 3.5 compatibility

### DIFF
--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'cgi'
-
 module I18n
   class ExceptionHandler
     def call(exception, _locale, _key, _options)


### PR DESCRIPTION
In Ruby 3.5 this emits a warning since most of the `cgi` gem is being removed.

i18n doesn't use this module anymore since the require was added 11 years ago, so it can just be removed to avoid the warning during require.

https://bugs.ruby-lang.org/issues/21258