### PR TITLE
CI: Add Ruby 3.4 to CI Matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: [head, 3.3, 3.2, 3.1, '3.0', jruby]
+        ruby_version: [head, 3.4, 3.3, 3.2, 3.1, '3.0', jruby]
         gemfile:
           - Gemfile
           - gemfiles/Gemfile.rails-6.0.x

--- a/gemfiles/Gemfile.rails-6.0.x
+++ b/gemfiles/Gemfile.rails-6.0.x
@@ -8,6 +8,10 @@ gem 'test_declarative', '0.0.6'
 gem 'rake'
 gem 'minitest', '~> 5.14'
 gem 'racc'
+gem 'base64'
+gem 'mutex_m'
+gem 'bigdecimal'
+gem 'concurrent-ruby', '1.3.4'
 
 platforms :mri do
   gem 'oj'

--- a/gemfiles/Gemfile.rails-6.1.x
+++ b/gemfiles/Gemfile.rails-6.1.x
@@ -10,6 +10,8 @@ gem 'minitest', '~> 5.14'
 gem 'racc'
 gem 'base64'
 gem 'mutex_m'
+gem 'bigdecimal'
+gem 'concurrent-ruby', '1.3.4'
 
 platforms :mri do
   gem 'oj'

--- a/gemfiles/Gemfile.rails-6.1.x
+++ b/gemfiles/Gemfile.rails-6.1.x
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'activesupport', '~> 6.1'
+gem 'activesupport', '~> 6.1.0'
 gem 'mocha', '~> 2.1.0'
 gem 'test_declarative', '0.0.6'
 gem 'rake'

--- a/gemfiles/Gemfile.rails-7.0.x
+++ b/gemfiles/Gemfile.rails-7.0.x
@@ -8,6 +8,9 @@ gem 'test_declarative', '0.0.6'
 gem 'rake'
 gem 'minitest', '~> 5.14'
 gem 'racc'
+gem 'mutex_m'
+gem 'bigdecimal'
+gem 'concurrent-ruby', '1.3.4'
 
 platforms :mri do
   gem 'oj'

--- a/gemfiles/Gemfile.rails-7.0.x
+++ b/gemfiles/Gemfile.rails-7.0.x
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'activesupport', '~> 7.0'
+gem 'activesupport', '~> 7.0.0'
 gem 'mocha', '~> 2.1.0'
 gem 'test_declarative', '0.0.6'
 gem 'rake'

--- a/gemfiles/Gemfile.rails-7.1.x
+++ b/gemfiles/Gemfile.rails-7.1.x
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'activesupport', '~> 7.1'
+gem 'activesupport', '~> 7.1.0'
 gem 'mocha', '~> 2'
 gem 'test_declarative', '0.0.6'
 gem 'rake'

--- a/gemfiles/Gemfile.rails-7.2.x
+++ b/gemfiles/Gemfile.rails-7.2.x
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'activesupport', '~> 7.2'
+gem 'activesupport', '~> 7.2.0'
 gem 'mocha', '~> 2'
 gem 'test_declarative', '0.0.6'
 gem 'rake'

--- a/gemfiles/Gemfile.rails-8.0.x
+++ b/gemfiles/Gemfile.rails-8.0.x
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'activesupport', '~> 8.0'
+gem 'activesupport', '~> 8.0.0'
 gem 'mocha', '~> 2'
 gem 'test_declarative', '0.0.6'
 gem 'rake'


### PR DESCRIPTION
This Pull Request adds Ruby 3.4 to the CI matrix.
Additionally, it fixes the Rails version specification in gemfiles so that CI runs against the intended minor version.

### Details
#### Add dependencies for Ruby 3.4 in CI Gemfiles
Since `mutex_m` and `bigdecimal` cause the following errors on Ruby 3.4, dependencies have been added to the Gemfiles for each Rails version in CI where these errors occur.
This is because these gems were moved from `default gems` to `bundled gems` in Ruby 3.4.
https://github.com/ruby/ruby/blob/v3_4_0/NEWS.md?plain=1#L333-L352

```
LoadError: cannot load such file -- mutex_m
/home/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require': cannot load such file -- bigdecimal (LoadError)
```

#### Fix CI Error of `uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)` for rails 7.0 or below

`concurrent-ruby` v1.3.4 has been added for compatibility with Rails versions <= 7.0.
This resolves an error that occurs with Rails <= 7.0 and `concurrent-ruby` v1.3.5:
- https://github.com/rails/rails/issues/54260

The error details are as follows:
```
/home/runner/work/i18n/i18n/vendor/bundle/ruby/3.3.0/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:16:in `<module:LoggerThreadSafeLevel>': uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)

    Logger::Severity.constants.each do |severity|
    ^^^^^^
	from /home/runner/work/i18n/i18n/vendor/bundle/ruby/3.3.0/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:9:in `<module:ActiveSupport>'
...
```
https://github.com/ruby-i18n/i18n/actions/runs/18092846741/job/51477245834

#### Fix Rails version specification in gemfiles
In CI, jobs such as `build (3.3, gemfiles/Gemfile.rails-7.1.x)` were running against Rails 7.2 instead of Rails 7.1.
This Pull Request updates the version specification to ensure that the intended Rails minor version is used.

Example change (Gemfile.rails-7.1.x):
```diff
-gem 'activesupport', '~> 7.1'
+gem 'activesupport', '~> 7.1.0'
```

Before this fix, the Rails 7.1 CI lockfile was already pulling in Rails 7.2:
```
Print lockfile
  /usr/bin/cat gemfiles/Gemfile.rails-7.1.x.lock
...
  GEM
    remote: https://rubygems.org/
    specs:
      activesupport (7.2.2.2)
        base64
```
https://github.com/ruby-i18n/i18n/actions/runs/18093519210/job/51479436380
