### PR TITLE
Fix I18n.locale reset in Fiber context by using Thread#thread_variaable

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -55,12 +55,13 @@ module I18n
   module Base
     # Gets I18n configuration object.
     def config
-      Thread.current[:i18n_config] ||= I18n::Config.new
+      Thread.current.thread_variable_get(:i18n_config) ||
+        Thread.current.thread_variable_set(:i18n_config, I18n::Config.new)
     end
 
     # Sets I18n configuration object.
     def config=(value)
-      Thread.current[:i18n_config] = value
+      Thread.current.thread_variable_set(:i18n_config, value)
     end
 
     # Write methods which delegates to the configuration object

--- a/lib/i18n/middleware.rb
+++ b/lib/i18n/middleware.rb
@@ -10,7 +10,7 @@ module I18n
     def call(env)
       @app.call(env)
     ensure
-      Thread.current[:i18n_config] = I18n::Config.new
+      Thread.current.thread_variable_set(:i18n_config, I18n::Config.new)
     end
 
   end

--- a/test/i18n/middleware_test.rb
+++ b/test/i18n/middleware_test.rb
@@ -9,10 +9,10 @@ class I18nMiddlewareTest < I18n::TestCase
   end
 
   test "middleware initializes new config object after request" do
-    old_i18n_config_object_id = Thread.current[:i18n_config].object_id
+    old_i18n_config_object_id = Thread.current.thread_variable_get(:i18n_config).object_id
     @middleware.call({})
 
-    updated_i18n_config_object_id = Thread.current[:i18n_config].object_id
+    updated_i18n_config_object_id = Thread.current.thread_variable_get(:i18n_config).object_id
     refute_equal updated_i18n_config_object_id, old_i18n_config_object_id
   end
 

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -59,7 +59,7 @@ class I18nTest < I18n::TestCase
   test "sets the current locale to Thread.current" do
     assert_nothing_raised { I18n.locale = 'de' }
     assert_equal :de, I18n.locale
-    assert_equal :de, Thread.current[:i18n_config].locale
+    assert_equal :de, Thread.current.thread_variable_get(:i18n_config).locale
     I18n.locale = :en
   end
 
@@ -80,7 +80,7 @@ class I18nTest < I18n::TestCase
     begin
       I18n.config = self
       assert_equal self, I18n.config
-      assert_equal self, Thread.current[:i18n_config]
+      assert_equal self, Thread.current.thread_variable_get(:i18n_config)
     ensure
       I18n.config = ::I18n::Config.new
     end
@@ -547,5 +547,18 @@ class I18nTest < I18n::TestCase
     ensure
       I18n.instance_variable_set(:@reserved_keys_pattern, nil)
     end
+  end
+
+  test "I18n.locale is preserved in Fiber context" do
+    I18n.available_locales = [:en, :ja]
+    I18n.default_locale = :ja
+    I18n.locale = :en
+
+    fiber_locale = nil
+    Fiber.new do
+      fiber_locale = I18n.locale
+    end.resume
+
+    assert_equal :en, fiber_locale
   end
 end


### PR DESCRIPTION
Related issue: https://github.com/ruby-i18n/i18n/issues/723

## Summary

This PR fixes an issue where I18n.locale is unexpectedly reset when entering a new Fiber context.

Currently, I18n stores its configuration with Thread.current[:i18n_config].
However, in Ruby, Thread.current[:key] is fiber-local, not strictly thread-local.
As a result, each Fiber gets its own isolated config, and I18n.locale falls back to default_locale inside new Fibers.

## Fix

Switch to Thread#thread_variable_get/set, which provides true thread-local storage and is inherited by Fibers.
