### PR TITLE
Add a new `I18n.isolation_scope=` option to explicitly use threads or fibers

### DIFF
--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -563,7 +563,7 @@ class I18nTest < I18n::TestCase
     end
   end
 
-  test "I18n.locale is preserved in Fiber context" do
+  test "I18n.locale is preserved in Fiber context when using Thread locals" do
     I18n.available_locales = [:en, :ja]
     I18n.default_locale = :ja
     I18n.locale = :en
@@ -574,5 +574,23 @@ class I18nTest < I18n::TestCase
     end.resume
 
     assert_equal :en, fiber_locale
+  end
+
+  test "I18n.locale is preserved in Fiber context when using Fiber locals" do
+    begin
+      I18n.isolation_scope = :fiber
+      I18n.available_locales = [:en, :ja]
+      I18n.default_locale = :ja
+      I18n.locale = :en
+
+      fiber_locale = nil
+      Fiber.new do
+        fiber_locale = I18n.locale
+      end.resume
+
+      assert_equal :en, fiber_locale
+    ensure
+      I18n.isolation_scope = :thread
+    end
   end
 end

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -63,6 +63,20 @@ class I18nTest < I18n::TestCase
     I18n.locale = :en
   end
 
+  test "isolation_scope= can set the current isolation scope to Fiber[]" do
+    begin
+      assert_nothing_raised {
+        I18n.isolation_scope = :fiber
+        I18n.locale = 'de'
+      }
+      assert_equal :de, I18n.locale
+      assert_equal :de, Fiber[:i18n_config].locale
+      I18n.locale = :en
+    ensure
+      I18n.isolation_scope = :thread
+    end
+  end
+
   test "locale= doesn't ignore junk" do
     assert_raises(NoMethodError) { I18n.locale = Class }
   end


### PR DESCRIPTION
After the update on #723 (https://github.com/ruby-i18n/i18n/pull/724) I18n became incompatible with web servers like Falcon, that serve every request in a new fiber. You can read my comment on that issue for a bit more context.

This PR introduces a new option called `I18n.isolation_scope` which allows you to configure where you'd like the instance of `I18n::Config` to be stored. By default it stays as a thread variable, but it can be changed to use fibers like so:

```ruby
I18n.isolation_scope = :fiber
```

By using `:fiber` we store the config in a fiber local `Fiber[:i18n_config]` instead of thread local `Thread.current.thread_variable_get`.