### PR TITLE
Fiber-aware I18n config storage 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         rubyopt: [""]
-        ruby_version: [head, 3.4, 3.3, 3.2, jruby]
+        ruby_version: [head, 3.4, 3.3, jruby]
         gemfile:
           - Gemfile
           - gemfiles/Gemfile.rails-7.0.x

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,6 +35,9 @@ jobs:
             gemfile: gemfiles/Gemfile.rails-8.0.x
           - ruby_version: jruby
             gemfile: gemfiles/Gemfile.rails-main
+          # Rails main now requires Ruby >= 3.3 (activesupport)
+          - ruby_version: 3.2
+            gemfile: gemfiles/Gemfile.rails-main
         include:
           - ruby_version: 3.4
             gemfile: Gemfile

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ I18n.locale = :de
 I18n.t(:test) # => "Dies ist ein Test"
 ```
 
+### Fiber-safe config updates
+
+`Fiber[]` values are inherited by child fibers.
+To avoid sharing mutable config objects across fibers, prefer creating updated configs and setting them with `set!`:
+
+```ruby
+I18n.config.with(locale: :ja).set!
+```
+
+`set!` stores a frozen config in the current execution context.
+This keeps inherited state safe and lets updates happen by replacing config objects.
+
 ## Features
 
 * Translation and localization

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We support Rails versions from 6.0 and up.
 
 ### Ruby (without Rails)
 
-We support Ruby versions from 3.0 and up.
+We support Ruby versions from 3.2 and up.
 
 If you want to use this library without Rails, you can simply add `i18n` to your `Gemfile`:
 

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -69,11 +69,25 @@ module I18n
       end
     end
 
+    # Gets a mutable I18n configuration object.
+    def writable_config
+      current = config
+      return current unless current.frozen?
+
+      current = current.dup
+      if Fiber.respond_to?(:[])
+        Fiber[:i18n_config] = current
+      else
+        Thread.current.thread_variable_set(:i18n_config, current)
+      end
+      current
+    end
+
     # Sets I18n configuration object.
     def config=(value)
       if Fiber.respond_to?(:[])
         Fiber[:i18n_config] = value
-        value.owner = Fiber.current if value.respond_to?(:owner=)
+        value.owner = Fiber.current if value.respond_to?(:owner=) && !value.frozen?
       else
         Thread.current.thread_variable_set(:i18n_config, value)
       end
@@ -88,7 +102,7 @@ module I18n
         end
 
         def #{method}=(value)
-          config.#{method} = (value)
+          writable_config.#{method} = (value)
         end
       DELEGATORS
     end

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -55,18 +55,13 @@ module I18n
   module Base
     # Gets I18n configuration object.
     def config
-      if Fiber.respond_to?(:[])
-        current = Fiber[:i18n_config] || self.config = I18n::Config.new
-        if current.respond_to?(:owned_by?) && !current.owned_by?(Fiber.current)
-          current = current.dup
-          Fiber[:i18n_config] = current
-        end
-
-        current
-      else
-        Thread.current.thread_variable_get(:i18n_config) ||
-          Thread.current.thread_variable_set(:i18n_config, I18n::Config.new)
+      current = Fiber[:i18n_config] || self.config = I18n::Config.new
+      if current.respond_to?(:owned_by?) && !current.owned_by?(Fiber.current)
+        current = current.dup
+        Fiber[:i18n_config] = current
       end
+
+      current
     end
 
     # Gets a mutable I18n configuration object.
@@ -75,22 +70,14 @@ module I18n
       return current unless current.frozen?
 
       current = current.dup
-      if Fiber.respond_to?(:[])
-        Fiber[:i18n_config] = current
-      else
-        Thread.current.thread_variable_set(:i18n_config, current)
-      end
+      Fiber[:i18n_config] = current
       current
     end
 
     # Sets I18n configuration object.
     def config=(value)
-      if Fiber.respond_to?(:[])
-        Fiber[:i18n_config] = value
-        value.owner = Fiber.current if value.respond_to?(:owner=) && !value.frozen?
-      else
-        Thread.current.thread_variable_set(:i18n_config, value)
-      end
+      Fiber[:i18n_config] = value
+      value.owner = Fiber.current if value.respond_to?(:owner=) && !value.frozen?
     end
 
     # Write methods which delegates to the configuration object

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -56,7 +56,13 @@ module I18n
     # Gets I18n configuration object.
     def config
       if Fiber.respond_to?(:[])
-        Fiber[:i18n_config] || self.config = I18n::Config.new
+        current = Fiber[:i18n_config] || self.config = I18n::Config.new
+        if current.respond_to?(:owned_by?) && !current.owned_by?(Fiber.current)
+          current = current.dup
+          Fiber[:i18n_config] = current
+        end
+
+        current
       else
         Thread.current.thread_variable_get(:i18n_config) ||
           Thread.current.thread_variable_set(:i18n_config, I18n::Config.new)
@@ -67,6 +73,7 @@ module I18n
     def config=(value)
       if Fiber.respond_to?(:[])
         Fiber[:i18n_config] = value
+        value.owner = Fiber.current if value.respond_to?(:owner=)
       else
         Thread.current.thread_variable_set(:i18n_config, value)
       end

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -55,13 +55,21 @@ module I18n
   module Base
     # Gets I18n configuration object.
     def config
-      Thread.current.thread_variable_get(:i18n_config) ||
-        Thread.current.thread_variable_set(:i18n_config, I18n::Config.new)
+      if Fiber.respond_to?(:[])
+        Fiber[:i18n_config] || self.config = I18n::Config.new
+      else
+        Thread.current.thread_variable_get(:i18n_config) ||
+          Thread.current.thread_variable_set(:i18n_config, I18n::Config.new)
+      end
     end
 
     # Sets I18n configuration object.
     def config=(value)
-      Thread.current.thread_variable_set(:i18n_config, value)
+      if Fiber.respond_to?(:[])
+        Fiber[:i18n_config] = value
+      else
+        Thread.current.thread_variable_set(:i18n_config, value)
+      end
     end
 
     # Write methods which delegates to the configuration object

--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -16,21 +16,13 @@ module I18n
     # Returns the current fallbacks implementation. Defaults to +I18n::Locale::Fallbacks+.
     def fallbacks
       @@fallbacks ||= I18n::Locale::Fallbacks.new
-      if Fiber.respond_to?(:[])
-        Fiber[:i18n_fallbacks] || @@fallbacks
-      else
-        Thread.current[:i18n_fallbacks] || @@fallbacks
-      end
+      Fiber[:i18n_fallbacks] || @@fallbacks
     end
 
     # Sets the current fallbacks implementation. Use this to set a different fallbacks implementation.
     def fallbacks=(fallbacks)
       @@fallbacks = fallbacks.is_a?(Array) ? I18n::Locale::Fallbacks.new(fallbacks) : fallbacks
-      if Fiber.respond_to?(:[])
-        Fiber[:i18n_fallbacks] = @@fallbacks
-      else
-        Thread.current[:i18n_fallbacks] = @@fallbacks
-      end
+      Fiber[:i18n_fallbacks] = @@fallbacks
     end
   end
 

--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -16,13 +16,21 @@ module I18n
     # Returns the current fallbacks implementation. Defaults to +I18n::Locale::Fallbacks+.
     def fallbacks
       @@fallbacks ||= I18n::Locale::Fallbacks.new
-      Thread.current[:i18n_fallbacks] || @@fallbacks
+      if Fiber.respond_to?(:[])
+        Fiber[:i18n_fallbacks] || @@fallbacks
+      else
+        Thread.current[:i18n_fallbacks] || @@fallbacks
+      end
     end
 
     # Sets the current fallbacks implementation. Use this to set a different fallbacks implementation.
     def fallbacks=(fallbacks)
       @@fallbacks = fallbacks.is_a?(Array) ? I18n::Locale::Fallbacks.new(fallbacks) : fallbacks
-      Thread.current[:i18n_fallbacks] = @@fallbacks
+      if Fiber.respond_to?(:[])
+        Fiber[:i18n_fallbacks] = @@fallbacks
+      else
+        Thread.current[:i18n_fallbacks] = @@fallbacks
+      end
     end
   end
 

--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -26,6 +26,24 @@ module I18n
       @owner = Fiber.current
     end
 
+    # Returns a copied configuration with the provided attributes set.
+    def with(**attrs)
+      dup.tap do |copy|
+        attrs.each do |name, value|
+          copy.public_send("#{name}=", value)
+        end
+      end
+    end
+
+    # Sets this configuration as the current one for the active execution context.
+    # The stored configuration is frozen to avoid sharing mutable state between fibers.
+    def set!
+      self.owner = Fiber.current unless frozen?
+      freeze
+      I18n.config = self
+      self
+    end
+
     # Sets the current locale pseudo-globally, i.e. in the Thread.current or Fiber local hash.
     def locale=(locale)
       I18n.enforce_available_locales!(locale)

--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -10,7 +10,23 @@ module I18n
       defined?(@locale) && @locale != nil ? @locale : default_locale
     end
 
-    # Sets the current locale pseudo-globally, i.e. in the Thread.current hash.
+    def initialize
+      @owner = Fiber.current
+    end
+
+    def owned_by?(fiber)
+      @owner == fiber
+    end
+
+    def owner=(fiber)
+      @owner = fiber
+    end
+
+    def initialize_copy(other)
+      @owner = Fiber.current
+    end
+
+    # Sets the current locale pseudo-globally, i.e. in the Thread.current or Fiber local hash.
     def locale=(locale)
       I18n.enforce_available_locales!(locale)
       @locale = locale && locale.to_sym

--- a/lib/i18n/middleware.rb
+++ b/lib/i18n/middleware.rb
@@ -10,7 +10,11 @@ module I18n
     def call(env)
       @app.call(env)
     ensure
-      Thread.current.thread_variable_set(:i18n_config, I18n::Config.new)
+      if Fiber.respond_to?(:[])
+        Fiber[:i18n_config] = I18n::Config.new
+      else
+        Thread.current.thread_variable_set(:i18n_config, I18n::Config.new)
+      end
     end
 
   end

--- a/lib/i18n/middleware.rb
+++ b/lib/i18n/middleware.rb
@@ -10,11 +10,7 @@ module I18n
     def call(env)
       @app.call(env)
     ensure
-      if Fiber.respond_to?(:[])
-        Fiber[:i18n_config] = I18n::Config.new
-      else
-        Thread.current.thread_variable_set(:i18n_config, I18n::Config.new)
-      end
+      Fiber[:i18n_config] = I18n::Config.new
     end
 
   end

--- a/test/i18n/middleware_test.rb
+++ b/test/i18n/middleware_test.rb
@@ -9,18 +9,10 @@ class I18nMiddlewareTest < I18n::TestCase
   end
 
   test "middleware initializes new config object after request" do
-    old_i18n_config_object_id = if Fiber.respond_to?(:[])
-      Fiber[:i18n_config].object_id
-    else
-      Thread.current.thread_variable_get(:i18n_config).object_id
-    end
+    old_i18n_config_object_id = Fiber[:i18n_config].object_id
     @middleware.call({})
 
-    updated_i18n_config_object_id = if Fiber.respond_to?(:[])
-      Fiber[:i18n_config].object_id
-    else
-      Thread.current.thread_variable_get(:i18n_config).object_id
-    end
+    updated_i18n_config_object_id = Fiber[:i18n_config].object_id
     refute_equal updated_i18n_config_object_id, old_i18n_config_object_id
   end
 

--- a/test/i18n/middleware_test.rb
+++ b/test/i18n/middleware_test.rb
@@ -9,10 +9,18 @@ class I18nMiddlewareTest < I18n::TestCase
   end
 
   test "middleware initializes new config object after request" do
-    old_i18n_config_object_id = Thread.current.thread_variable_get(:i18n_config).object_id
+    old_i18n_config_object_id = if Fiber.respond_to?(:[])
+      Fiber[:i18n_config].object_id
+    else
+      Thread.current.thread_variable_get(:i18n_config).object_id
+    end
     @middleware.call({})
 
-    updated_i18n_config_object_id = Thread.current.thread_variable_get(:i18n_config).object_id
+    updated_i18n_config_object_id = if Fiber.respond_to?(:[])
+      Fiber[:i18n_config].object_id
+    else
+      Thread.current.thread_variable_get(:i18n_config).object_id
+    end
     refute_equal updated_i18n_config_object_id, old_i18n_config_object_id
   end
 

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -90,8 +90,38 @@ class I18nTest < I18n::TestCase
         assert_equal self, Thread.current.thread_variable_get(:i18n_config)
       end
     ensure
-      I18n.config = ::I18n::Config.new
+      ::I18n::Config.new.set!
     end
+  end
+
+  test "config#with returns a copied configuration with overrides" do
+    base = I18n::Config.new
+    base.locale = :en
+
+    copy = base.with(locale: :de)
+
+    assert_equal :en, base.locale
+    assert_equal :de, copy.locale
+    refute_equal base.object_id, copy.object_id
+  end
+
+  test "config#with raises when an unknown attribute is passed" do
+    assert_raises(NoMethodError) { I18n::Config.new.with(unknown_attribute: true) }
+  end
+
+  test "config#set! stores a frozen config and keeps I18n setters usable" do
+    I18n.available_locales = [:en, :de]
+    config = I18n::Config.new.with(locale: :en)
+
+    assert_same config, config.set!
+    assert_same config, I18n.config
+    assert config.frozen?
+    assert_raises(FrozenError) { config.locale = :de }
+
+    I18n.locale = :de
+    refute_same config, I18n.config
+    assert_equal :en, config.locale
+    assert_equal :de, I18n.locale
   end
 
   test "locale is not shared between configurations" do

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -56,14 +56,10 @@ class I18nTest < I18n::TestCase
     assert_equal I18n.default_locale, I18n.locale
   end
 
-  test "sets the current locale to Thread.current or Fiber local" do
+  test "sets the current locale to Fiber local" do
     assert_nothing_raised { I18n.locale = 'de' }
     assert_equal :de, I18n.locale
-    if Fiber.respond_to?(:[])
-      assert_equal :de, Fiber[:i18n_config].locale
-    else
-      assert_equal :de, Thread.current.thread_variable_get(:i18n_config).locale
-    end
+    assert_equal :de, Fiber[:i18n_config].locale
     I18n.locale = :en
   end
 
@@ -84,11 +80,7 @@ class I18nTest < I18n::TestCase
     begin
       I18n.config = self
       assert_equal self, I18n.config
-      if Fiber.respond_to?(:[])
-        assert_equal self, Fiber[:i18n_config]
-      else
-        assert_equal self, Thread.current.thread_variable_get(:i18n_config)
-      end
+      assert_equal self, Fiber[:i18n_config]
     ensure
       ::I18n::Config.new.set!
     end
@@ -601,7 +593,6 @@ class I18nTest < I18n::TestCase
   end
 
   test "I18n.locale is isolated between concurrent Fibers" do
-    skip "Fiber storage requires Ruby 3.2+" unless Fiber.respond_to?(:[])
     I18n.available_locales = [:en, :ja]
     I18n.default_locale = :en
     I18n.locale = :en
@@ -625,8 +616,6 @@ class I18nTest < I18n::TestCase
   end
 
   test "I18n.locale write in child Fiber does not leak to parent" do
-    skip "Fiber storage requires Ruby 3.2+" unless Fiber.respond_to?(:[])
-
     I18n.available_locales = [:en, :ja]
     I18n.default_locale = :en
     I18n.locale = :en

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -569,4 +569,54 @@ class I18nTest < I18n::TestCase
 
     assert_equal :en, fiber_locale
   end
+
+  test "I18n.locale is isolated between concurrent Fibers" do
+    skip "Fiber storage requires Ruby 3.2+" unless Fiber.respond_to?(:[])
+    I18n.available_locales = [:en, :ja]
+    I18n.default_locale = :en
+    I18n.locale = :en
+
+    fiber_ja = Fiber.new do
+      I18n.locale = :ja
+      Fiber.yield I18n.locale
+      I18n.locale
+    end
+
+    fiber_en = Fiber.new do
+      I18n.locale = :en
+      Fiber.yield I18n.locale
+      I18n.locale
+    end
+
+    assert_equal :ja, fiber_ja.resume
+    assert_equal :en, fiber_en.resume
+    assert_equal :ja, fiber_ja.resume
+    assert_equal :en, fiber_en.resume
+  end
+
+  test "I18n.locale write in child Fiber does not leak to parent" do
+    skip "Fiber storage requires Ruby 3.2+" unless Fiber.respond_to?(:[])
+
+    I18n.available_locales = [:en, :ja]
+    I18n.default_locale = :en
+    I18n.locale = :en
+
+    parent_locale = I18n.locale
+    parent_config_id = I18n.config.object_id
+
+    child_saw_locale = nil
+    child_config_id = nil
+
+    Fiber.new do
+      child_saw_locale = I18n.locale
+      child_config_id = I18n.config.object_id
+
+      I18n.locale = :ja
+      assert_equal :ja, I18n.locale
+    end.resume
+
+    assert_equal parent_locale, I18n.locale
+    assert_equal :en, child_saw_locale
+    refute_equal parent_config_id, child_config_id
+  end
 end

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -56,10 +56,14 @@ class I18nTest < I18n::TestCase
     assert_equal I18n.default_locale, I18n.locale
   end
 
-  test "sets the current locale to Thread.current" do
+  test "sets the current locale to Thread.current or Fiber local" do
     assert_nothing_raised { I18n.locale = 'de' }
     assert_equal :de, I18n.locale
-    assert_equal :de, Thread.current.thread_variable_get(:i18n_config).locale
+    if Fiber.respond_to?(:[])
+      assert_equal :de, Fiber[:i18n_config].locale
+    else
+      assert_equal :de, Thread.current.thread_variable_get(:i18n_config).locale
+    end
     I18n.locale = :en
   end
 
@@ -80,7 +84,11 @@ class I18nTest < I18n::TestCase
     begin
       I18n.config = self
       assert_equal self, I18n.config
-      assert_equal self, Thread.current.thread_variable_get(:i18n_config)
+      if Fiber.respond_to?(:[])
+        assert_equal self, Fiber[:i18n_config]
+      else
+        assert_equal self, Thread.current.thread_variable_get(:i18n_config)
+      end
     ensure
       I18n.config = ::I18n::Config.new
     end


### PR DESCRIPTION
This PR improves `I18n.locale`/config behavior in Fiber-based runtimes:

* `Thread.current[:i18n_config]` is fiber-local, so entering a new Fiber can “lose” locale/config and fall back to `default_locale` (e.g. CSV/Enumerator creating Fibers).
* A true thread-local (`Thread#thread_variable_*`) avoids that, but can cause cross-request locale leakage in fiber-per-request servers (e.g. Falcon).

### What this PR does

* Use Fiber storage (`Fiber[]`) when available to preserve locale/config across child Fibers.
* Add Copy-on-Write so writes (e.g. `I18n.locale=`) don’t mutate shared state: `Config#set!` freezes the stored config, and setters duplicate as needed before mutating.
* Keep a fallback path for environments without Fiber storage.

I’m still unsure whether i18n should require Ruby 3.2+ (so Fiber storage is always available) or keep supporting older Rubies with the fallback path; feedback welcome.

issue: https://github.com/ruby-i18n/i18n/issues/723