### PR TITLE
CI: exclude Ruby 3.2 from rails-main matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,6 +35,9 @@ jobs:
             gemfile: gemfiles/Gemfile.rails-8.0.x
           - ruby_version: jruby
             gemfile: gemfiles/Gemfile.rails-main
+          # Rails main requires Ruby 3.3+
+          - ruby_version: 3.2
+            gemfile: gemfiles/Gemfile.rails-main
         include:
           - ruby_version: 3.4
             gemfile: Gemfile


### PR DESCRIPTION
Rails main now requires Ruby 3.3+, so the `Ruby 3.2` × `gemfiles/Gemfile.rails-main` matrix combination can no longer `bundle install` and fails CI.

Exclude that single combination, matching the existing JRuby exclusions for rails-main. All other Ruby 3.2 gemfile combinations are kept.