### PR TITLE
Fix feature fiber storage

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         rubyopt: [""]
-        ruby_version: [head, 3.4, 3.3, jruby]
+        ruby_version: [head, 3.4, 3.3, 3.2, jruby]
         gemfile:
           - Gemfile
           - gemfiles/Gemfile.rails-7.0.x

--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.platform     = Gem::Platform::RUBY
   s.require_path = 'lib'
   s.required_rubygems_version = '>= 1.3.5'
-  s.required_ruby_version = '>= 3.1'
+  s.required_ruby_version = '>= 3.2'
   s.add_dependency 'concurrent-ruby', '~> 1.0'
 end


### PR DESCRIPTION
Fixes #735.

## Summary

`i18n` 1.15.0 uses `Fiber[:i18n_config]`, but `Fiber.[]` is only available starting from Ruby 3.2. The README already documents Ruby 3.2+ support, but the gemspec still allowed Ruby 3.1, which lets Bundler install a version that fails at runtime on Ruby 3.1.

This PR updates the gemspec to require Ruby `>= 3.2` and adds Ruby 3.2 back to the CI matrix so the minimum supported Ruby version is tested.

## Testing

I could not run the full test suite locally because my local Ruby is 3.1.7 and dependencies are not installed.

I verified locally that Ruby 3.1.7 does not support `Fiber.[]`:

```ruby
Fiber.respond_to?(:[])
# => false