### PR TITLE
Ignore Ruby 3.2 + Rails main from the matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,6 +35,8 @@ jobs:
             gemfile: gemfiles/Gemfile.rails-8.0.x
           - ruby_version: jruby
             gemfile: gemfiles/Gemfile.rails-main
+          - ruby_version: 3.2
+            gemfile: gemfiles/Gemfile.rails-main
         include:
           - ruby_version: 3.4
             gemfile: Gemfile


### PR DESCRIPTION
Rails main now requires at least Ruby 3.3