### PR TITLE
Restore Ruby 3.1 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         rubyopt: [""]
-        ruby_version: [head, 3.4, 3.3, 3.2, jruby]
+        ruby_version: [head, 3.4, 3.3, 3.2, 3.1, jruby]
         gemfile:
           - Gemfile
           - gemfiles/Gemfile.rails-7.0.x
@@ -36,6 +36,12 @@ jobs:
           - ruby_version: jruby
             gemfile: gemfiles/Gemfile.rails-main
           - ruby_version: 3.2
+            gemfile: gemfiles/Gemfile.rails-main
+          # Rails 8.0.x requires Ruby 3.2+
+          - ruby_version: 3.1
+            gemfile: gemfiles/Gemfile.rails-8.0.x
+          # Rails main requires Ruby 3.3+
+          - ruby_version: 3.1
             gemfile: gemfiles/Gemfile.rails-main
         include:
           - ruby_version: 3.4

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We support Rails versions from 6.0 and up.
 
 ### Ruby (without Rails)
 
-We support Ruby versions from 3.2 and up.
+We support Ruby versions from 3.1 and up.
 
 If you want to use this library without Rails, you can simply add `i18n` to your `Gemfile`:
 

--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.platform     = Gem::Platform::RUBY
   s.require_path = 'lib'
   s.required_rubygems_version = '>= 1.3.5'
-  s.required_ruby_version = '>= 3.2'
+  s.required_ruby_version = '>= 3.1'
   s.add_dependency 'concurrent-ruby', '~> 1.0'
 end

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -55,13 +55,18 @@ module I18n
   module Base
     # Gets I18n configuration object.
     def config
-      current = Fiber[:i18n_config] || self.config = I18n::Config.new
-      if current.respond_to?(:owned_by?) && !current.owned_by?(Fiber.current)
-        current = current.dup
-        Fiber[:i18n_config] = current
-      end
+      if Fiber.respond_to?(:[])
+        current = Fiber[:i18n_config] || self.config = I18n::Config.new
+        if current.respond_to?(:owned_by?) && !current.owned_by?(Fiber.current)
+          current = current.dup
+          Fiber[:i18n_config] = current
+        end
 
-      current
+        current
+      else
+        Thread.current.thread_variable_get(:i18n_config) ||
+          Thread.current.thread_variable_set(:i18n_config, I18n::Config.new)
+      end
     end
 
     # Gets a mutable I18n configuration object.
@@ -70,14 +75,22 @@ module I18n
       return current unless current.frozen?
 
       current = current.dup
-      Fiber[:i18n_config] = current
+      if Fiber.respond_to?(:[])
+        Fiber[:i18n_config] = current
+      else
+        Thread.current.thread_variable_set(:i18n_config, current)
+      end
       current
     end
 
     # Sets I18n configuration object.
     def config=(value)
-      Fiber[:i18n_config] = value
-      value.owner = Fiber.current if value.respond_to?(:owner=) && !value.frozen?
+      if Fiber.respond_to?(:[])
+        Fiber[:i18n_config] = value
+        value.owner = Fiber.current if value.respond_to?(:owner=) && !value.frozen?
+      else
+        Thread.current.thread_variable_set(:i18n_config, value)
+      end
     end
 
     # Write methods which delegates to the configuration object

--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -16,13 +16,21 @@ module I18n
     # Returns the current fallbacks implementation. Defaults to +I18n::Locale::Fallbacks+.
     def fallbacks
       @@fallbacks ||= I18n::Locale::Fallbacks.new
-      Fiber[:i18n_fallbacks] || @@fallbacks
+      if Fiber.respond_to?(:[])
+        Fiber[:i18n_fallbacks] || @@fallbacks
+      else
+        Thread.current[:i18n_fallbacks] || @@fallbacks
+      end
     end
 
     # Sets the current fallbacks implementation. Use this to set a different fallbacks implementation.
     def fallbacks=(fallbacks)
       @@fallbacks = fallbacks.is_a?(Array) ? I18n::Locale::Fallbacks.new(fallbacks) : fallbacks
-      Fiber[:i18n_fallbacks] = @@fallbacks
+      if Fiber.respond_to?(:[])
+        Fiber[:i18n_fallbacks] = @@fallbacks
+      else
+        Thread.current[:i18n_fallbacks] = @@fallbacks
+      end
     end
   end
 

--- a/lib/i18n/middleware.rb
+++ b/lib/i18n/middleware.rb
@@ -10,7 +10,11 @@ module I18n
     def call(env)
       @app.call(env)
     ensure
-      Fiber[:i18n_config] = I18n::Config.new
+      if Fiber.respond_to?(:[])
+        Fiber[:i18n_config] = I18n::Config.new
+      else
+        Thread.current.thread_variable_set(:i18n_config, I18n::Config.new)
+      end
     end
 
   end

--- a/test/i18n/middleware_test.rb
+++ b/test/i18n/middleware_test.rb
@@ -9,10 +9,18 @@ class I18nMiddlewareTest < I18n::TestCase
   end
 
   test "middleware initializes new config object after request" do
-    old_i18n_config_object_id = Fiber[:i18n_config].object_id
+    old_i18n_config_object_id = if Fiber.respond_to?(:[])
+      Fiber[:i18n_config].object_id
+    else
+      Thread.current.thread_variable_get(:i18n_config).object_id
+    end
     @middleware.call({})
 
-    updated_i18n_config_object_id = Fiber[:i18n_config].object_id
+    updated_i18n_config_object_id = if Fiber.respond_to?(:[])
+      Fiber[:i18n_config].object_id
+    else
+      Thread.current.thread_variable_get(:i18n_config).object_id
+    end
     refute_equal updated_i18n_config_object_id, old_i18n_config_object_id
   end
 

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -56,10 +56,14 @@ class I18nTest < I18n::TestCase
     assert_equal I18n.default_locale, I18n.locale
   end
 
-  test "sets the current locale to Fiber local" do
+  test "sets the current locale to Thread.current or Fiber local" do
     assert_nothing_raised { I18n.locale = 'de' }
     assert_equal :de, I18n.locale
-    assert_equal :de, Fiber[:i18n_config].locale
+    if Fiber.respond_to?(:[])
+      assert_equal :de, Fiber[:i18n_config].locale
+    else
+      assert_equal :de, Thread.current.thread_variable_get(:i18n_config).locale
+    end
     I18n.locale = :en
   end
 
@@ -80,7 +84,11 @@ class I18nTest < I18n::TestCase
     begin
       I18n.config = self
       assert_equal self, I18n.config
-      assert_equal self, Fiber[:i18n_config]
+      if Fiber.respond_to?(:[])
+        assert_equal self, Fiber[:i18n_config]
+      else
+        assert_equal self, Thread.current.thread_variable_get(:i18n_config)
+      end
     ensure
       ::I18n::Config.new.set!
     end
@@ -593,6 +601,7 @@ class I18nTest < I18n::TestCase
   end
 
   test "I18n.locale is isolated between concurrent Fibers" do
+    skip "Fiber storage requires Ruby 3.2+" unless Fiber.respond_to?(:[])
     I18n.available_locales = [:en, :ja]
     I18n.default_locale = :en
     I18n.locale = :en
@@ -616,6 +625,8 @@ class I18nTest < I18n::TestCase
   end
 
   test "I18n.locale write in child Fiber does not leak to parent" do
+    skip "Fiber storage requires Ruby 3.2+" unless Fiber.respond_to?(:[])
+
     I18n.available_locales = [:en, :ja]
     I18n.default_locale = :en
     I18n.locale = :en


### PR DESCRIPTION
i18n 1.15.1 raised the required Ruby version to 3.2 to address #735, where Ruby 3.1 users hit `NoMethodError: undefined method '[]' for Fiber:Class`. As a result, Ruby 3.1 users remain on the broken i18n 1.15.0 release and cannot upgrade to a fixed version.

Restore Ruby 3.1 support and ship a patch that works on both Ruby 3.1 and Ruby 3.2 so that Ruby 3.1 users can upgrade to 1.15.x without incompatibility. On Ruby without the `Fiber[]` storage API (Ruby 3.1), the config and fallbacks storage falls back to thread-local variables; on Ruby 3.2+ it keeps using Fiber storage. The previously removed test branches and Fiber-isolation skip guards are brought back as regression coverage for the Ruby 3.1 path.

This approach also lets existing Ruby 3.1 users who pin `gem "i18n", "!= 1.15.0"` in their Gemfile use i18n 1.15.2 and later without incompatibility.

The CI matrix gains Ruby 3.1, excluding the Rails 8.0.x (requires Ruby 3.2+) and Rails main (requires Ruby 3.3+) gemfiles which do not support Ruby 3.1.

Although Ruby 3.1 is already EOL, libraries (unlike applications) provide value by remaining usable for a broad range of users, so the thread-local fallback path is intentionally retained for environments without `Fiber[]` (including JRuby 9.4).