### PR TITLE
Ractor support

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -475,10 +475,16 @@ module I18n
       end
     end
 
-    @@normalized_key_cache = I18n.new_double_nested_cache
+    def normalized_key_cache
+      if defined?(Ractor)
+        Ractor.current[:i18n_normalized_key_cache] ||= I18n.new_double_nested_cache
+      else
+        @@normalized_key_cache ||= I18n.new_double_nested_cache
+      end
+    end
 
     def normalize_key(key, separator)
-      @@normalized_key_cache[separator][key] ||=
+      normalized_key_cache[separator][key] ||=
         case key
         when Array
           key.flat_map { |k| normalize_key(k, separator) }

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -16,7 +16,7 @@ module I18n
   autoload :Tests,   'i18n/tests'
   autoload :Middleware,   'i18n/middleware'
 
-  RESERVED_KEYS = %i[
+  @reserved_keys = %i[
     cascade
     deep_interpolation
     skip_interpolation
@@ -32,11 +32,17 @@ module I18n
     scope
     separator
     throw
-  ]
+  ].freeze
   EMPTY_HASH = {}.freeze
 
   def self.new_double_nested_cache # :nodoc:
     Concurrent::Map.new { |h, k| h[k] = Concurrent::Map.new }
+  end
+
+  # Returns the current set of reserved keys. Reserved keys are used
+  # internally, and can't also be used for interpolation.
+  def self.reserved_keys
+    @reserved_keys
   end
 
   # Marks a key as reserved. Reserved keys are used internally,
@@ -44,13 +50,17 @@ module I18n
   # extra keys as I18n options, you should call I18n.reserve_key
   # before any I18n.translate (etc) calls are made.
   def self.reserve_key(key)
-    RESERVED_KEYS << key.to_sym
+    @reserved_keys = (@reserved_keys + [key.to_sym]).freeze
     @reserved_keys_pattern = nil
   end
 
   def self.reserved_keys_pattern # :nodoc:
-    @reserved_keys_pattern ||= /(?<!%)%\{(#{RESERVED_KEYS.join("|")})\}/
+    @reserved_keys_pattern ||= /(?<!%)%\{(#{@reserved_keys.join("|")})\}/
   end
+  @reserved_keys_pattern = reserved_keys_pattern
+
+  RESERVED_KEYS = @reserved_keys
+  deprecate_constant :RESERVED_KEYS
 
   module Base
     # Gets I18n configuration object.

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -130,6 +130,7 @@ module I18n
     # is useful.
     def eager_load!
       config.backend.eager_load!
+      Locale::Tag.implementation
     end
 
     # Translates, pluralizes and interpolates a given key using a given locale,

--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -55,7 +55,7 @@ module I18n
 
         deep_interpolation = options[:deep_interpolation]
         skip_interpolation = options[:skip_interpolation]
-        values = Utils.except(options, *RESERVED_KEYS) unless options.empty?
+        values = Utils.except(options, *I18n.reserved_keys) unless options.empty?
         if !skip_interpolation && values && !values.empty?
           entry = if deep_interpolation
             deep_interpolate(locale, entry, values)

--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -8,6 +8,9 @@ module I18n
     module Base
       include I18n::Backend::Transliterator
 
+      # Evaluation context for translation files.
+      TRANSLATION_FILE_CONTEXT = Object.new.freeze
+
       # Accepts a list of paths to translation files. Loads translations from
       # plain Ruby (*.rb), YAML files (*.yml), or JSON files (*.json). See #load_rb, #load_yml, and #load_json
       # for details.
@@ -252,7 +255,7 @@ module I18n
         # Loads a plain Ruby translations file. eval'ing the file must yield
         # a Hash containing translation data with locales as toplevel keys.
         def load_rb(filename)
-          translations = eval(IO.read(filename), binding, filename.to_s)
+          translations = TRANSLATION_FILE_CONTEXT.instance_eval(IO.read(filename), filename.to_s)
           [translations, false]
         end
 

--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -14,18 +14,27 @@ module I18n
 
   class << self
     # Returns the current fallbacks implementation. Defaults to +I18n::Locale::Fallbacks+.
+    # When not explicitly set, a frozen default instance is returned without
+    # writing the class variable, so reads from non-main Ractors do not
+    # trigger isolation violations.
     def fallbacks
-      @@fallbacks ||= I18n::Locale::Fallbacks.new
-      if Fiber.respond_to?(:[])
+      current = if Fiber.respond_to?(:[])
         Fiber[:i18n_fallbacks] || @@fallbacks
       else
         Thread.current[:i18n_fallbacks] || @@fallbacks
       end
+      current || I18n::Locale::Fallbacks.new.freeze
     end
 
     # Sets the current fallbacks implementation. Use this to set a different fallbacks implementation.
     def fallbacks=(fallbacks)
-      @@fallbacks = fallbacks.is_a?(Array) ? I18n::Locale::Fallbacks.new(fallbacks) : fallbacks
+      @@fallbacks = if fallbacks.nil?
+        nil
+      elsif fallbacks.is_a?(Array)
+        I18n::Locale::Fallbacks.new(fallbacks).freeze
+      else
+        fallbacks.freeze
+      end
       if Fiber.respond_to?(:[])
         Fiber[:i18n_fallbacks] = @@fallbacks
       else

--- a/lib/i18n/backend/interpolation_compiler.rb
+++ b/lib/i18n/backend/interpolation_compiler.rb
@@ -62,7 +62,7 @@ module I18n
 
         def interpolate_or_raise_missing(key)
           escaped_key = escape_key_sym(key)
-          RESERVED_KEYS.include?(key) ? reserved_key(escaped_key) : interpolate_key(escaped_key)
+          I18n.reserved_keys.include?(key) ? reserved_key(escaped_key) : interpolate_key(escaped_key)
         end
 
         def interpolate_key(key)

--- a/lib/i18n/backend/metadata.rb
+++ b/lib/i18n/backend/metadata.rb
@@ -44,7 +44,7 @@ module I18n
           :scope     => options[:scope],
           :default   => options[:default],
           :separator => options[:separator],
-          :values    => options.reject { |name, _value| RESERVED_KEYS.include?(name) }
+          :values    => options.reject { |name, _value| I18n.reserved_keys.include?(name) }
         }
         with_metadata(metadata) { super }
       end

--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -71,11 +71,7 @@ module I18n
           # call `init_translations`
           init_translations if do_init && !initialized?
 
-          @translations ||= Concurrent::Hash.new do |h, k|
-            MUTEX.synchronize do
-              h[k] = Concurrent::Hash.new
-            end
-          end
+          @translations ||= Concurrent::Hash.new
         end
 
       protected

--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -50,150 +50,175 @@ module I18n
       @locale = locale && locale.to_sym
     end
 
-    # Returns the current backend. Defaults to +Backend::Simple+.
-    def backend
-      @@backend ||= Backend::Simple.new
-    end
+    @enforce_available_locales = true
 
-    # Sets the current backend. Used to set a custom backend.
-    def backend=(backend)
-      @@backend = backend
-    end
-
-    # Returns the current default locale. Defaults to :'en'
-    def default_locale
-      @@default_locale ||= :en
-    end
-
-    # Sets the current default locale. Used to set a custom default locale.
-    def default_locale=(locale)
-      I18n.enforce_available_locales!(locale)
-      @@default_locale = locale && locale.to_sym
-    end
-
-    # Returns an array of locales for which translations are available.
-    # Unless you explicitly set these through I18n.available_locales=
-    # the call will be delegated to the backend.
-    def available_locales
-      @@available_locales ||= nil
-      @@available_locales || backend.available_locales
-    end
-
-    # Caches the available locales list as both strings and symbols in a Set, so
-    # that we can have faster lookups to do the available locales enforce check.
-    def available_locales_set #:nodoc:
-      @@available_locales_set ||= available_locales.inject(Set.new) do |set, locale|
-        set << locale.to_s << locale.to_sym
+    class << self
+      # Returns the current backend. Defaults to +Backend::Simple+.
+      def backend
+        @backend ||= Backend::Simple.new
       end
-    end
 
-    # Sets the available locales.
-    def available_locales=(locales)
-      @@available_locales = Array(locales).map { |locale| locale.to_sym }
-      @@available_locales = nil if @@available_locales.empty?
-      @@available_locales_set = nil
-    end
-
-    # Returns true if the available_locales have been initialized
-    def available_locales_initialized?
-      ( !!defined?(@@available_locales) && !!@@available_locales )
-    end
-
-    # Clears the available locales set so it can be recomputed again after I18n
-    # gets reloaded.
-    def clear_available_locales_set #:nodoc:
-      @@available_locales_set = nil
-    end
-
-    # Returns the current default scope separator. Defaults to '.'
-    def default_separator
-      @@default_separator ||= '.'
-    end
-
-    # Sets the current default scope separator.
-    def default_separator=(separator)
-      @@default_separator = separator
-    end
-
-    # Returns the current exception handler. Defaults to an instance of
-    # I18n::ExceptionHandler.
-    def exception_handler
-      @@exception_handler ||= ExceptionHandler.new
-    end
-
-    # Sets the exception handler.
-    def exception_handler=(exception_handler)
-      @@exception_handler = exception_handler
-    end
-
-    # Returns the current handler for situations when interpolation argument
-    # is missing. MissingInterpolationArgument will be raised by default.
-    def missing_interpolation_argument_handler
-      @@missing_interpolation_argument_handler ||= lambda do |missing_key, provided_hash, string|
-        raise MissingInterpolationArgument.new(missing_key, provided_hash, string)
+      # Sets the current backend. Used to set a custom backend.
+      def backend=(backend)
+        @backend = backend
       end
+
+      # Returns the current default locale. Defaults to :'en'
+      def default_locale
+        @default_locale ||= :en
+      end
+
+      # Sets the current default locale. Used to set a custom default locale.
+      def default_locale=(locale)
+        I18n.enforce_available_locales!(locale)
+        @default_locale = locale && locale.to_sym
+      end
+
+      # Returns an array of locales for which translations are available.
+      # Unless you explicitly set these through I18n.available_locales=
+      # the call will be delegated to the backend.
+      def available_locales
+        @available_locales || backend.available_locales
+      end
+
+      # Caches the available locales list as both strings and symbols in a Set, so
+      # that we can have faster lookups to do the available locales enforce check.
+      def available_locales_set #:nodoc:
+        @available_locales_set ||= available_locales.inject(Set.new) do |set, locale|
+          set << locale.to_s << locale.to_sym
+        end
+      end
+
+      # Sets the available locales.
+      def available_locales=(locales)
+        @available_locales = Array(locales).map { |locale| locale.to_sym }
+        @available_locales = nil if @available_locales.empty?
+        @available_locales_set = nil
+      end
+
+      # Returns true if the available_locales have been initialized
+      def available_locales_initialized?
+        ( !!defined?(@available_locales) && !!@available_locales )
+      end
+
+      # Clears the available locales set so it can be recomputed again after I18n
+      # gets reloaded.
+      def clear_available_locales_set #:nodoc:
+        @available_locales_set = nil
+      end
+
+      # Returns the current default scope separator. Defaults to '.'
+      def default_separator
+        @default_separator ||= '.'
+      end
+
+      # Sets the current default scope separator.
+      def default_separator=(separator)
+        @default_separator = separator
+      end
+
+      # Returns the current exception handler. Defaults to an instance of
+      # I18n::ExceptionHandler.
+      def exception_handler
+        @exception_handler ||= ExceptionHandler.new
+      end
+
+      # Sets the exception handler.
+      def exception_handler=(exception_handler)
+        @exception_handler = exception_handler
+      end
+
+      # Returns the current handler for situations when interpolation argument
+      # is missing. MissingInterpolationArgument will be raised by default.
+      def missing_interpolation_argument_handler
+        @missing_interpolation_argument_handler ||= lambda do |missing_key, provided_hash, string|
+          raise MissingInterpolationArgument.new(missing_key, provided_hash, string)
+        end
+      end
+
+      # Sets the missing interpolation argument handler. It can be any
+      # object that responds to #call. The arguments that will be passed to #call
+      # are the same as for MissingInterpolationArgument initializer. Use +Proc.new+
+      # if you don't care about arity.
+      #
+      # == Example:
+      # You can suppress raising an exception and return string instead:
+      #
+      #   I18n.config.missing_interpolation_argument_handler = Proc.new do |key|
+      #     "#{key} is missing"
+      #   end
+      def missing_interpolation_argument_handler=(exception_handler)
+        @missing_interpolation_argument_handler = exception_handler
+      end
+
+      # Allow clients to register paths providing translation data sources. The
+      # backend defines acceptable sources.
+      #
+      # E.g. the provided SimpleBackend accepts a list of paths to translation
+      # files which are either named *.rb and contain plain Ruby Hashes or are
+      # named *.yml and contain YAML data. So for the SimpleBackend clients may
+      # register translation files like this:
+      #   I18n.load_path << 'path/to/locale/en.yml'
+      def load_path
+        @load_path ||= []
+      end
+
+      # Sets the load path instance. Custom implementations are expected to
+      # behave like a Ruby Array.
+      def load_path=(load_path)
+        @load_path = load_path
+        @available_locales_set = nil
+        backend.reload!
+      end
+
+      # Whether or not to verify if locales are in the list of available locales.
+      # Defaults to true.
+      def enforce_available_locales
+        @enforce_available_locales
+      end
+
+      def enforce_available_locales=(enforce_available_locales)
+        @enforce_available_locales = enforce_available_locales
+      end
+
+      # Returns the current interpolation patterns. Defaults to
+      # I18n::DEFAULT_INTERPOLATION_PATTERNS.
+      def interpolation_patterns
+        @interpolation_patterns ||= I18n::DEFAULT_INTERPOLATION_PATTERNS.dup
+      end
+
+      # Sets the current interpolation patterns. Used to set a interpolation
+      # patterns.
+      #
+      # E.g. using {{}} as a placeholder like "{{hello}}, world!":
+      #
+      #   I18n.config.interpolation_patterns << /\{\{(\w+)\}\}/
+      def interpolation_patterns=(interpolation_patterns)
+        @interpolation_patterns = interpolation_patterns
+      end
+
     end
 
-    # Sets the missing interpolation argument handler. It can be any
-    # object that responds to #call. The arguments that will be passed to #call
-    # are the same as for MissingInterpolationArgument initializer. Use +Proc.new+
-    # if you don't care about arity.
-    #
-    # == Example:
-    # You can suppress raising an exception and return string instead:
-    #
-    #   I18n.config.missing_interpolation_argument_handler = Proc.new do |key|
-    #     "#{key} is missing"
-    #   end
-    def missing_interpolation_argument_handler=(exception_handler)
-      @@missing_interpolation_argument_handler = exception_handler
-    end
-
-    # Allow clients to register paths providing translation data sources. The
-    # backend defines acceptable sources.
-    #
-    # E.g. the provided SimpleBackend accepts a list of paths to translation
-    # files which are either named *.rb and contain plain Ruby Hashes or are
-    # named *.yml and contain YAML data. So for the SimpleBackend clients may
-    # register translation files like this:
-    #   I18n.load_path << 'path/to/locale/en.yml'
-    def load_path
-      @@load_path ||= []
-    end
-
-    # Sets the load path instance. Custom implementations are expected to
-    # behave like a Ruby Array.
-    def load_path=(load_path)
-      @@load_path = load_path
-      @@available_locales_set = nil
-      backend.reload!
-    end
-
-    # Whether or not to verify if locales are in the list of available locales.
-    # Defaults to true.
-    @@enforce_available_locales = true
-    def enforce_available_locales
-      @@enforce_available_locales
-    end
-
-    def enforce_available_locales=(enforce_available_locales)
-      @@enforce_available_locales = enforce_available_locales
-    end
-
-    # Returns the current interpolation patterns. Defaults to
-    # I18n::DEFAULT_INTERPOLATION_PATTERNS.
-    def interpolation_patterns
-      @@interpolation_patterns ||= I18n::DEFAULT_INTERPOLATION_PATTERNS.dup
-    end
-
-    # Sets the current interpolation patterns. Used to set a interpolation
-    # patterns.
-    #
-    # E.g. using {{}} as a placeholder like "{{hello}}, world!":
-    #
-    #   I18n.config.interpolation_patterns << /\{\{(\w+)\}\}/
-    def interpolation_patterns=(interpolation_patterns)
-      @@interpolation_patterns = interpolation_patterns
-    end
+    def backend; Config.backend; end
+    def backend=(backend); Config.backend = backend; end
+    def default_locale; Config.default_locale; end
+    def default_locale=(locale); Config.default_locale = locale; end
+    def available_locales; Config.available_locales; end
+    def available_locales=(locales); Config.available_locales = locales; end
+    def available_locales_set; Config.available_locales_set; end
+    def available_locales_initialized?; Config.available_locales_initialized?; end
+    def clear_available_locales_set; Config.clear_available_locales_set; end
+    def default_separator; Config.default_separator; end
+    def default_separator=(separator); Config.default_separator = separator; end
+    def exception_handler; Config.exception_handler; end
+    def exception_handler=(exception_handler); Config.exception_handler = exception_handler; end
+    def missing_interpolation_argument_handler; Config.missing_interpolation_argument_handler; end
+    def missing_interpolation_argument_handler=(exception_handler); Config.missing_interpolation_argument_handler = exception_handler; end
+    def load_path; Config.load_path; end
+    def load_path=(load_path); Config.load_path = load_path; end
+    def enforce_available_locales; Config.enforce_available_locales; end
+    def enforce_available_locales=(enforce_available_locales); Config.enforce_available_locales = enforce_available_locales; end
+    def interpolation_patterns; Config.interpolation_patterns; end
+    def interpolation_patterns=(interpolation_patterns); Config.interpolation_patterns = interpolation_patterns; end
   end
 end

--- a/lib/i18n/interpolate/ruby.rb
+++ b/lib/i18n/interpolate/ruby.rb
@@ -12,10 +12,14 @@ module I18n
   INTERPOLATION_PATTERN = Regexp.union(DEFAULT_INTERPOLATION_PATTERNS)
   deprecate_constant :INTERPOLATION_PATTERN
 
-  INTERPOLATION_PATTERNS_CACHE = Hash.new do |hash, patterns|
-    hash[patterns] = Regexp.union(patterns)
+  def self.interpolation_patterns_cache
+    if defined?(Ractor)
+      Ractor.current[:i18n_interpolation_patterns_cache] ||= {}
+    else
+      @interpolation_patterns_cache ||= {}
+    end
   end
-  private_constant :INTERPOLATION_PATTERNS_CACHE
+  private_class_method :interpolation_patterns_cache
 
   class << self
     # Return String or raises MissingInterpolationArgument exception.
@@ -27,7 +31,7 @@ module I18n
     end
 
     def interpolate_hash(string, values)
-      pattern = INTERPOLATION_PATTERNS_CACHE[config.interpolation_patterns]
+      pattern = interpolation_patterns_cache[config.interpolation_patterns] ||= Regexp.union(config.interpolation_patterns)
       interpolated = false
 
       interpolated_string = string.gsub(pattern) do |match|

--- a/lib/i18n/locale/fallbacks.rb
+++ b/lib/i18n/locale/fallbacks.rb
@@ -61,7 +61,7 @@ module I18n
         raise InvalidLocale.new(locale) if locale.nil?
         raise Disabled.new('fallback#[]') if locale == false
         locale = locale.to_sym
-        super || store(locale, compute(locale))
+        super || (frozen? ? compute(locale) : store(locale, compute(locale)))
       end
 
       def map(*args, &block)
@@ -77,6 +77,13 @@ module I18n
         else
           @map.map(*args, &block)
         end
+      end
+
+      def freeze
+        return self if frozen?
+        @map&.freeze
+        @defaults&.freeze
+        super
       end
 
       def empty?

--- a/lib/i18n/locale/tag.rb
+++ b/lib/i18n/locale/tag.rb
@@ -7,15 +7,17 @@ module I18n
       autoload :Rfc4646, 'i18n/locale/tag/rfc4646'
       autoload :Simple,  'i18n/locale/tag/simple'
 
+      @implementation = nil
+
       class << self
         # Returns the current locale tag implementation. Defaults to +I18n::Locale::Tag::Simple+.
         def implementation
-          @@implementation ||= Simple
+          @implementation ||= Simple
         end
 
         # Sets the current locale tag implementation. Use this to set a different locale tag implementation.
         def implementation=(implementation)
-          @@implementation = implementation
+          @implementation = implementation
         end
 
         # Factory method for locale tags. Delegates to the current locale tag implementation.

--- a/lib/i18n/ractorize.rb
+++ b/lib/i18n/ractorize.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "i18n"
+
+I18n.eager_load!
+
+Ractor.make_shareable(I18n.config.backend)

--- a/lib/i18n/ractorize.rb
+++ b/lib/i18n/ractorize.rb
@@ -4,4 +4,21 @@ require "i18n"
 
 I18n.eager_load!
 
-Ractor.make_shareable(I18n.config.backend)
+I18n::Config.available_locales = I18n::Config.available_locales
+Ractor.make_shareable(I18n::Config.backend)
+Ractor.make_shareable(I18n::Config.available_locales)
+Ractor.make_shareable(I18n::Config.available_locales_set)
+Ractor.make_shareable(I18n::Config.exception_handler)
+Ractor.make_shareable(I18n::Config.interpolation_patterns)
+Ractor.make_shareable(I18n::Config.load_path)
+
+config = I18n.config
+config.available_locales_set
+config.default_locale
+config.default_separator
+config.exception_handler
+config.interpolation_patterns
+config.load_path
+config.owner = nil
+
+Ractor.make_shareable(config)

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -151,7 +151,7 @@ class I18nBackendSimpleTest < I18n::TestCase
       I18n.available_locales = [:en, :es]
       store_translations(:fr, :foo => {:bar => 'barfr', :baz => 'bazfr'})
       store_translations(:es, :foo => {:bar => 'bares', :baz => 'bazes'})
-      assert_equal translations[:fr], {}
+      assert_nil translations[:fr]
       assert_equal Hash[:foo, {:bar => 'bares', :baz => 'bazes'}], translations[:es]
     ensure
       I18n.config.enforce_available_locales = false

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -575,14 +575,15 @@ class I18nTest < I18n::TestCase
 
   test "can reserve a key" do
     begin
-      stub_const(I18n, :RESERVED_KEYS, []) do
-        I18n.reserve_key(:foo)
-        I18n.reserve_key("bar")
+      old_reserved_keys = I18n.reserved_keys
+      I18n.instance_variable_set(:@reserved_keys, [].freeze)
+      I18n.reserve_key(:foo)
+      I18n.reserve_key("bar")
 
-        assert I18n::RESERVED_KEYS.include?(:foo)
-        assert I18n::RESERVED_KEYS.include?(:bar)
-      end
+      assert I18n.reserved_keys.include?(:foo)
+      assert I18n.reserved_keys.include?(:bar)
     ensure
+      I18n.instance_variable_set(:@reserved_keys, old_reserved_keys)
       I18n.instance_variable_set(:@reserved_keys_pattern, nil)
     end
   end


### PR DESCRIPTION
Rails has recently started [implementing experimental support](https://github.com/rails/rails/pulls?q=is%3Apr+is%3Aopen+ractor+label%3A%22Ractor+Support%22) for [Ractors](https://docs.ruby-lang.org/en/master/language/ractor_md.html), and I noticed this library needs a few changes to properly be used on non-main Ractors. Here's the changes I made:

- Introduce `I18n.reserved_keys` that uses an instance variable instead of `RESERVED_KEYS` and assigns and re-freezes keys.
- Freeze `I18n::INTERPOLATION_PATTERN` and converts `INTERPOLATION_PATTERNS_CACHE` to a instance variable that assigns and re-freezes the cache.
- Introduce `I18n.normalized_key_cache` that uses Ractor-local storage when not on the main Ractor.
- Make I18n backends ractor sahreable.
- Make I18n configs ractor sahreable via `i18n/ractorize`
- Make I18n locale tags ractor sahreable.

We may want to look at refactoring other pieces of I18n to freeze + use class variables + eagerly memoize in order to make Ractor safe, but this looks sufficient for most of what Rails needs.